### PR TITLE
 Clean up dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 
 # dependencies
 /node_modules
+package-lock.json
+yarn.lock
 
 # testing
 /coverage

--- a/package.json
+++ b/package.json
@@ -48,31 +48,27 @@
     "start": "stripes serve",
     "build": "stripes build --output ./output",
     "test": "stripes test nightmare --run demo --show",
-    "lint": "eslint src"
+    "lint": "eslint ."
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^1.1.0",
-    "@folio/stripes-cli": "^1.2.0",
-    "babel-core": "^6.17.0",
-    "babel-eslint": "^8.2.6",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "babel-register": "^6.18.0",
-    "eslint": "^4.8.0"
+    "@folio/eslint-config-stripes": "^3.2.1",
+    "@folio/stripes-cli": "^1.4.0",
+    "@folio/stripes-connect": "^3.1.1",
+    "@folio/stripes-core": "^2.9.0",
+    "@folio/stripes-logger": "^0.0.2",
+    "babel-eslint": "^9.0.0",
+    "eslint": "^5.6.0",
+    "react": "^16.5.1",
+    "react-dom": "^16.5.1"
   },
   "dependencies": {
     "@folio/stripes-components": "^3.0.0",
-    "@folio/stripes-form": "^0.8.2",
-    "@folio/stripes-smart-components": "^1.4.23",
-    "eslint": "^4.8.0",
+    "@folio/stripes-form": "^0.9.0",
+    "@folio/stripes-smart-components": "^1.8.0",
     "lodash": "^4.17.5",
     "prop-types": "^15.5.10",
-    "query-string": "^5.0.0",
-    "react-router-dom": "^4.1.1",
-    "redux-form": "^7.3.0",
-    "style-loader": "^0.20.1",
-    "uuid": "^3.1.0"
+    "react-intl": "^2.5.0",
+    "react-router-dom": "^4.1.1"
   },
   "peerDependencies": {
     "@folio/stripes-connect": "^3.1.1",

--- a/src/components/PO/PO.js
+++ b/src/components/PO/PO.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { Icon, IconButton, AccordionSet, Accordion, ExpandAllButton, Pane, PaneMenu, Row, Col, Button, IfPermission, Layer } from '@folio/stripes-components';
+import { Icon, IconButton, AccordionSet, Accordion, ExpandAllButton, Pane, PaneMenu, Row, Col, Button, IfPermission } from '@folio/stripes-components';
 import transitionToParams from '@folio/stripes-components/util/transitionToParams';
 import FundDistribution from '../FundDistribution';
 import LineListing from '../LineListing';
@@ -71,17 +71,20 @@ class PO extends Component {
   render() {
     const { location } = this.props;
     const initialValues = this.getData();
-    const lastMenu = (<PaneMenu>
-      <IfPermission perm="vendor.item.put">
-        <IconButton
-          icon="edit"
-          id="clickable-editvendor"
-          style={{ visibility: !initialValues ? 'hidden' : 'visible' }}
-          onClick={this.props.onEdit}
-          href={this.props.editLink}
-          title="Edit Vendor"
-        />
-      </IfPermission> </PaneMenu>);
+    const lastMenu = (
+      <PaneMenu>
+        <IfPermission perm="vendor.item.put">
+          <IconButton
+            icon="edit"
+            id="clickable-editvendor"
+            style={{ visibility: !initialValues ? 'hidden' : 'visible' }}
+            onClick={this.props.onEdit}
+            href={this.props.editLink}
+            title="Edit Vendor"
+          />
+        </IfPermission>
+      </PaneMenu>
+    );
     const addPOLineButton = (<Button onClick={this.onAddPOLine}>Add PO Line</Button>);
 
     if (!initialValues) {

--- a/src/components/PO/POForm.js
+++ b/src/components/PO/POForm.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import stripesForm from '@folio/stripes-form';
-import { Pane, PaneMenu, Button, Row, Icon, Col, IconButton, IfPermission, Layer, AccordionSet, Accordion, ExpandAllButton } from '@folio/stripes-components';
+import { Pane, PaneMenu, Button, Row, Icon, Col, IfPermission, AccordionSet, Accordion, ExpandAllButton } from '@folio/stripes-components';
 import { PODetailsForm } from '../PODetails';
 import { SummaryForm } from '../Summary';
 
@@ -36,8 +36,8 @@ class POForm extends Component {
     const { onCancel } = this.props;
     return (
       <PaneMenu>
-        <button id="clickable-close-new-purchase-order-dialog" onClick={onCancel} title="close" aria-label="Close New Purchase Order Dialog">
-          <span style={{ fontSize: '30px', color: '#999', lineHeight: '18px' }} >&times;</span>
+        <button type="button" id="clickable-close-new-purchase-order-dialog" onClick={onCancel} title="close" aria-label="Close New Purchase Order Dialog">
+          <span style={{ fontSize: '30px', color: '#999', lineHeight: '18px' }}>&times;</span>
         </button>
       </PaneMenu>
     );
@@ -89,9 +89,12 @@ class POForm extends Component {
 
   render() {
     const { initialValues, onCancel } = this.props;
-    console.log(this.props);
     const firstMenu = this.getAddFirstMenu();
-    const paneTitle = initialValues.id ? <span>Edit: {_.get(initialValues, ['id'], '')} </span> : 'Create Order';
+    const paneTitle = initialValues.id ? (
+      <span>
+        {`Edit: ${_.get(initialValues, ['id'], '')}`}
+      </span>
+    ) : 'Create Order';
     const lastMenu = initialValues.id ?
       this.getLastMenu('clickable-update-purchase-order', 'Update Order') :
       this.getLastMenu('clickable-create-new-purchase-order', 'Create Order');
@@ -152,4 +155,3 @@ export default stripesForm({
   navigationCheck: true,
   enableReinitialize: true,
 })(POForm);
-

--- a/src/routes/Main.js
+++ b/src/routes/Main.js
@@ -106,7 +106,7 @@ class Main extends Component {
         params: {
           query: (...args) => {
             const resourceData = args[2];
-            let cql = `(name="${resourceData.poLineQuery.query}*")`;
+            const cql = `(name="${resourceData.poLineQuery.query}*")`;
             return cql;
           },
         },
@@ -127,7 +127,7 @@ class Main extends Component {
         params: {
           query: (...args) => {
             const resourceData = args[2];
-            let cql = `(id="${resourceData.poLineQuery.query}*")`;
+            const cql = `(id="${resourceData.poLineQuery.query}*")`;
             return cql;
           },
         },
@@ -185,7 +185,6 @@ class Main extends Component {
       </div>
     );
   }
-
 }
 
 export default Main;

--- a/test/ui-testing/demo.js
+++ b/test/ui-testing/demo.js
@@ -1,7 +1,7 @@
 /* global Nightmare, describe, it, before, after */
 
 module.exports.test = (uiTestCtx) => {
-  describe('Module test: ui-receiving:', function() {
+  describe('Module test: ui-receiving:', () => {
     const { config, helpers: { login, logout } } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
 
@@ -20,7 +20,7 @@ module.exports.test = (uiTestCtx) => {
           .click('#clickable-receiving-module')
           .wait('#receiving-module-display')
           .wait('#stripes-new-app-greeting')
-          .then(result => { done(); })
+          .then(() => { done(); })
           .catch(done);
       });
     });
@@ -41,7 +41,7 @@ module.exports.test = (uiTestCtx) => {
           .wait('a[href="/settings/receiving/general"]')
           .click('a[href="/settings/receiving/general"]')
           .wait('#stripes-new-app-settings-message')
-          .then(result => { done(); })
+          .then(() => { done(); })
           .catch(done);
       });
     });


### PR DESCRIPTION
Removes unnecessary `babel` packages and upgrades `eslint-config-stripes`.

Related to https://github.com/folio-org/ui-vendors/pull/41.

ESLint picked up a lot of missing imports? I don't see these files in the repo. Not sure what's going on there:
```
/ui-receiving/src/components/Panes/Panes.js
  6:20  error  Unable to resolve path to module '../POLine/POLine'  import/no-unresolved

/ui-receiving/src/components/PO/PO.js
   6:30  error  Unable to resolve path to module '../FundDistribution'  import/no-unresolved
   7:25  error  Unable to resolve path to module '../LineListing'       import/no-unresolved
   8:31  error  Unable to resolve path to module '../PODetails'         import/no-unresolved
   9:29  error  Unable to resolve path to module '../Summary'           import/no-unresolved
  10:29  error  Unable to resolve path to module '../LayerCollection'   import/no-unresolved

/ui-receiving/src/components/PO/POForm.js
  6:31  error  Unable to resolve path to module '../PODetails'  import/no-unresolved
  7:29  error  Unable to resolve path to module '../Summary'    import/no-unresolved
```