### PR TITLE
Replace stripes.intl.formatMessage with FormmatedMessage

### DIFF
--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import Settings from '@folio/stripes-components/lib/Settings';
 import GeneralSettings from './general-settings';
 import SomeFeatureSettings from './some-feature-settings';
@@ -13,12 +14,12 @@ export default class ReceivingSettings extends React.Component {
   pages = [
     {
       route: 'general',
-      label: this.props.stripes.intl.formatMessage({ id: 'ui-receiving.settings.general' }),
+      label: <FormattedMessage id="ui-receiving.settings.general" />,
       component: GeneralSettings,
     },
     {
       route: 'somefeature',
-      label: this.props.stripes.intl.formatMessage({ id: 'ui-receiving.settings.some-feature' }),
+      label: <FormattedMessage id="ui-receiving.settings.some-feature" />,
       component: SomeFeatureSettings,
     },
   ];


### PR DESCRIPTION
## Purpose
https://github.com/folio-org/stripes-core/pull/489

Retrieving the `intl` object from `this.context.intl` or the `stripes` god object (`stripes.intl`) is a deprecated pattern.

## Approach
- Use `<FormattedMessage>`, `<FormattedDate>`, and `<FormattedTime>` as often as possible, only falling back to `formatMessage()`, `formatDate()`, and `formatTime()` (accompanied by `injectIntl`) when a bare string is absolutely necessary.