### PR TITLE
UIREC-61 Caption not displayed when receiving or undeceiving pieces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Stories
 
+### Bug fixes
+* [UIREC-61](https://issues.folio.org/browse/UIREC-61) Caption not displayed when receiving or undeceiving pieces
+
 ## [1.0.0](https://github.com/folio-org/ui-receiving/tree/v1.0.0) (2020-03-13)
 
 ### Stories

--- a/src/TitleReceive/TitleReceiveList.js
+++ b/src/TitleReceive/TitleReceiveList.js
@@ -17,13 +17,31 @@ import {
 
 import { PIECE_FORMAT_LABELS } from '../common/constants';
 
-const visibleColumns = ['checked', 'barcode', 'format', 'hasRequest', 'comments', 'location', 'itemStatus', 'callNumber'];
+const visibleColumns = [
+  'checked',
+  'caption',
+  'barcode',
+  'format',
+  'hasRequest',
+  'comments',
+  'location',
+  'itemStatus',
+  'callNumber',
+];
 
 export const TitleReceiveList = ({ fields, props: { locationOptions, selectLocation, toggleCheckedAll } }) => {
   const field = fields.name;
   const cellFormatters = useMemo(
     () => {
       return {
+        caption: record => (
+          <Field
+            name={`${field}[${record.rowIndex}].caption`}
+            component={TextField}
+            marginBottom0
+            fullWidth
+          />
+        ),
         barcode: record => (
           <Field
             name={`${field}[${record.rowIndex}].barcode`}
@@ -99,6 +117,7 @@ export const TitleReceiveList = ({ fields, props: { locationOptions, selectLocat
           onChange={toggleAll}
         />
       ),
+      caption: <FormattedMessage id="ui-receiving.piece.caption" />,
       barcode: <FormattedMessage id="ui-receiving.piece.barcode" />,
       format: <FormattedMessage id="ui-receiving.piece.format" />,
       hasRequest: <FormattedMessage id="ui-receiving.piece.request" />,

--- a/src/TitleUnreceive/TitleUnreceiveList.js
+++ b/src/TitleUnreceive/TitleUnreceiveList.js
@@ -11,7 +11,16 @@ import {
 
 import { PIECE_FORMAT_LABELS } from '../common/constants';
 
-const visibleColumns = ['checked', 'barcode', 'format', 'hasRequest', 'comments', 'location', 'callNumber'];
+const visibleColumns = [
+  'checked',
+  'barcode',
+  'caption',
+  'format',
+  'hasRequest',
+  'comments',
+  'location',
+  'callNumber',
+];
 
 export const TitleUnreceiveList = ({ fields, props: { pieceLocationMap, toggleCheckedAll } }) => {
   const field = fields.name;
@@ -65,6 +74,7 @@ export const TitleUnreceiveList = ({ fields, props: { pieceLocationMap, toggleCh
         />
       ),
       barcode: <FormattedMessage id="ui-receiving.piece.barcode" />,
+      caption: <FormattedMessage id="ui-receiving.piece.caption" />,
       format: <FormattedMessage id="ui-receiving.piece.format" />,
       hasRequest: <FormattedMessage id="ui-receiving.piece.request" />,
       comments: <FormattedMessage id="ui-receiving.piece.comment" />,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Caption not displayed when receiving or undeceiving pieces
https://issues.folio.org/browse/UIREC-61
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
