### PR TITLE
UIREC-49 Save & close button should be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [UINV-138](https://issues.folio.org/browse/UINV-138) Align actions icons in table to right hand side of view pane(s)
 
 ### Bug fixes
+* [UIREC-49](https://issues.folio.org/browse/UIREC-49) Save & close button should be disabled until all required fields have values entered
 * [UIREC-46](https://issues.folio.org/browse/UIREC-46) Action buttons are not aligning to the right and are displaying states incorrectly
 * [UIREC-94](https://issues.folio.org/browse/UIREC-94) Ability to edit unreceived pieces
 * [UIREC-92](https://issues.folio.org/browse/UIREC-92) Add Piece modal keeps values from previously edited piece

--- a/src/TitleForm/TitleForm.js
+++ b/src/TitleForm/TitleForm.js
@@ -37,6 +37,7 @@ const ALLOWED_YEAR_LENGTH = 4;
 
 const TitleForm = ({
   handleSubmit,
+  hasValidationErrors,
   form,
   onCancel,
   pristine,
@@ -54,6 +55,7 @@ const TitleForm = ({
       pristine={pristine}
       submitting={submitting}
       onCancel={onCancel}
+      isSubmitDisabled={hasValidationErrors}
     />
   );
 
@@ -277,11 +279,12 @@ TitleForm.propTypes = {
   values: PropTypes.object.isRequired,  // current form values
   identifierTypes: PropTypes.arrayOf(PropTypes.object),
   contributorNameTypes: PropTypes.arrayOf(PropTypes.object),
+  hasValidationErrors: PropTypes.bool.isRequired,
 };
 
 export default stripesFinalForm({
   navigationCheck: true,
-  subscription: { values: true },
+  subscription: { hasValidationErrors: true, values: true },
   mutators: {
     setTitleValue: (args, state, tools) => {
       const { contributors, editions, publication, title, identifiers, id } = get(args, '0', {});


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Save & close button should be disabled until all required fields have values entered
https://issues.folio.org/browse/UIREC-49
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
