### PR TITLE
UIREC-136: Update circulation interface dependency to support v11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-receiving
 
 ## (IN PROGRESS)
+* Also support `circulation` `11.0`. Refs UIPCIR-21.
 
 ## [1.3.3](https://github.com/folio-org/ui-receiving/tree/v1.3.3) (2021-04-21)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v1.3.2...v1.3.3)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "home": "/receiving",
     "okapiInterfaces": {
       "acquisitions-units": "1.1",
-      "circulation": "9.5 10.0",
+      "circulation": "9.5 10.0 11.0",
       "configuration": "2.0",
       "contributor-types": "2.0",
       "holdings-storage": "4.2",


### PR DESCRIPTION
## Purpose
There is a breaking change in mod-circulation (https://github.com/folio-org/mod-circulation/pull/854), circulation interface version will be updated to 11.0.  Other modules should update their dependencies to support this change.

**Do not merge. We have several associated pull request and we need merge them at the same time.**

**API changes**
circulation/override-renewal-by-barcode - will be removed
circulation/renew-by-barcode - request and response will be changed
Current changes will be effect ui-users module

## Refs
https://issues.folio.org/browse/UIREC-136