### PR TITLE
UIREC-194: Also support `circulation` `12.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Display comment in receiving in column rather than on hover. Refs UIREC-193.
 * Allow user to choose what columns display for expected and received pieces. Refs UIREC-196.
 * Receiving app is reaching the display limit of 1000 pieces - User can't see newly created pieces. Refs UIREC-197.
+* Also support `circulation` `12.0`. Refs UIREC-194.
 
 ## [2.0.2](https://github.com/folio-org/ui-receiving/tree/v2.0.2) (2021-11-04)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v2.0.1...v2.0.2)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "home": "/receiving",
     "okapiInterfaces": {
       "acquisitions-units": "1.1",
-      "circulation": "9.5 10.0 11.0",
+      "circulation": "9.5 10.0 11.0 12.0",
       "configuration": "2.0",
       "contributor-types": "2.0",
       "holdings-storage": "4.2 5.0",


### PR DESCRIPTION
## Purpose
Support okapi interfaces `circulation` `12.0`

## Approach
* Title level requests changes affect ui-requests (UIREQ) without breaking change for this module.
* The implementation of title level requests requires data migration to allow for a single queue of requests, whether item or title level (https://issues.folio.org/browse/UXPROD-3330).

## Refs
https://issues.folio.org/browse/UIREC-194