### PR TITLE
UIREC-195: Also support circulation 13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Display comment in receiving in column rather than on hover. Refs UIREC-193.
 * Allow user to choose what columns display for expected and received pieces. Refs UIREC-196.
 * Add a return to Receiving default search to app context menu dropdown. Refs UIREC-201.
+* Also support `circulation` `13.0`. Refs UIREC-195.
 
 ## [2.0.3](https://github.com/folio-org/ui-receiving/tree/v2.0.3) (2021-12-08)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v2.0.2...v2.0.3)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "home": "/receiving",
     "okapiInterfaces": {
       "acquisitions-units": "1.1",
-      "circulation": "9.5 10.0 11.0 12.0",
+      "circulation": "9.5 10.0 11.0 12.0 13.0",
       "configuration": "2.0",
       "contributor-types": "2.0",
       "holdings-storage": "4.2 5.0",


### PR DESCRIPTION
## Purpose
Support okapi interfaces `circulation` `13.0`

## Approach
* Title level requests changes affect ui-requests (UIREQ) without breaking change for this module.
* Was changed API associated with request queue.

## Refs
https://issues.folio.org/browse/UIREC-195