### PR TITLE
UIREC-242: Support holdings-storage 6.0 in okapiInterfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add "Export results (CSV)" action to receiving app. Refs UIREC-233.
 * Allow user to select data points for Export results to CSV. Refs UIREC-234.
 * Export pieces functionality - FE approach. Refs UIREC-235.
+* Support holdings-storage 6.0 in okapiInterfaces. Refs UIREC-242.
 
 ## [2.1.0](https://github.com/folio-org/ui-receiving/tree/v2.1.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v2.0.3...v2.1.0)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "circulation": "9.5 10.0 11.0 12.0 13.0",
       "configuration": "2.0",
       "contributor-types": "2.0",
-      "holdings-storage": "4.2 5.0",
+      "holdings-storage": "4.2 5.0 6.0",
       "identifier-types": "1.2",
       "instance-formats": "2.0",
       "instance-types": "2.0",


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

ui-receiving uses the holdings-storage interface only, not the other two interfaces.

ui-receiving is not affected because the incompatible change is in the DELETE all APIs only that is not used by ui-receiving.

Only the okapiInterfaces need to be expanded in package.json.