### PR TITLE
UIREC-243: Support inventory 12.0 in okapiInterfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## (IN PROGRESS)
 
+* Support holdings-storage 6.0 in okapiInterfaces. Refs UIREC-242.
+* Support inventory 12.0 in okapiInterfaces. Refs UIREC-243.
+
 ## [2.2.0](https://github.com/folio-org/ui-receiving/tree/v2.2.0) (2022-07-07)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v2.1.0...v2.2.0)
 
@@ -16,7 +19,6 @@
 * Add "Export results (CSV)" action to receiving app. Refs UIREC-233.
 * Allow user to select data points for Export results to CSV. Refs UIREC-234.
 * Export pieces functionality - FE approach. Refs UIREC-235.
-* Support holdings-storage 6.0 in okapiInterfaces. Refs UIREC-242.
 
 ## [2.1.0](https://github.com/folio-org/ui-receiving/tree/v2.1.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v2.0.3...v2.1.0)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       "identifier-types": "1.2",
       "instance-formats": "2.0",
       "instance-types": "2.0",
-      "inventory": "10.0 11.0",
+      "inventory": "10.0 11.0 12.0",
       "location-units": "2.0",
       "locations": "3.0",
       "material-types": "2.2",


### PR DESCRIPTION
Add version 12.0 to the list of supported inventory interface versions.

DELETE /inventory/instances and DELETE /inventory/items have been deleting all records.

MODINV-731 changed them to delete records by CQL, this requires a major interface version bump.

ui-receiving doesn't use these two DELETE APIs therefore no code change is needed.

Fix holdings-storage 6.0 line in CHANGELOG.