### PR TITLE
UIREC-261 Extra holding appears when creating new holding for already existing location during 'Quick receive'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Align the module with API breaking change. Refs UIREC-256.
 * Map missed error codes with new translations. Refs UIREC-260.
 * *BREAKING*: Update `@folio/stripes` to `8.0.0`. Refs UIREC-257.
+* Extra holding appears when creating new holding for already existing location during "Quick receive". Refs UIREC-261.
 
 ## [2.3.1](https://github.com/folio-org/ui-receiving/tree/v2.3.1) (2022-11-30)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v2.3.0...v2.3.1)

--- a/src/TitleDetails/AddPieceModal/AddPieceModalContainer.js
+++ b/src/TitleDetails/AddPieceModal/AddPieceModalContainer.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { omit } from 'lodash';
 
@@ -39,7 +39,9 @@ const AddPieceModalContainer = ({
     onSubmit(values, { searchParams: { deleteHolding } }, isCreateAnother);
   };
 
-  const onQuickReceive = (formValues) => onCheckIn(omit(formValues, 'isCreateAnother'), formValues.isCreateAnother);
+  const onQuickReceive = useCallback((formValues) => (
+    onCheckIn(omit(formValues, 'isCreateAnother'), formValues.isCreateAnother)
+  ), [onCheckIn]);
 
   const orderFormat = poLine?.orderFormat;
   const pieceFormatOptions = orderFormat === ORDER_FORMATS.PEMix

--- a/src/common/hooks/useQuickReceive.js
+++ b/src/common/hooks/useQuickReceive.js
@@ -1,7 +1,10 @@
+import { useCallback } from 'react';
+
 import { useOkapiKy } from '@folio/stripes/core';
 
 import {
   getItemById,
+  getPieceById,
   getPieceStatusFromItem,
   getReceivingPieceItemStatus,
 } from '../utils';
@@ -13,9 +16,12 @@ export const useQuickReceive = () => {
   const { mutatePiece } = usePieceMutator();
   const { receive } = useReceive();
 
-  const quickReceive = (pieceValues) => {
+  const quickReceive = useCallback((pieceValues) => {
     return mutatePiece({ piece: pieceValues })
-      .then(async ({ itemId, ...piece }) => {
+      .then(async ({ id }) => {
+        const piece = await getPieceById({ GET: ({ path }) => ky.get(path) })(id).then(res => res.json());
+
+        const itemId = piece?.itemId;
         const item = itemId ? await getItemById(ky)(itemId) : {};
 
         const itemData = itemId
@@ -27,7 +33,7 @@ export const useQuickReceive = () => {
 
         return receive([{ ...piece, ...itemData }]);
       });
-  };
+  }, [ky, mutatePiece, receive]);
 
   return { quickReceive };
 };


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIREC-261
Quick receive action causes extra holding creation, when a new holding location was created for a corresponding piece.
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Quick receive action includes the following steps:
  1. create (or update) piece (POST (or PUT) /orders/pieces);
  2. receive piece (POST /orders/check-in);

As a PUT request does not return any data, currently for the second step initial piece values (from the UI form) are used instead of updated piece data. That might cause extra holdings creation.

Therefore updated piece should be retrieved before receiving.
## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
