### PR TITLE
UIREC-259 unpin @rehooks/local-storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Map missed error codes with new translations. Refs UIREC-260.
 * *BREAKING*: Update `@folio/stripes` to `8.0.0`. Refs UIREC-257.
 * Extra holding appears when creating new holding for already existing location during "Quick receive". Refs UIREC-261.
+* Unpin `@rehooks/local-storage` now that it's no longer broken. Refs UIREC-259.
 
 ## [2.3.1](https://github.com/folio-org/ui-receiving/tree/v2.3.1) (2022-11-30)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v2.3.0...v2.3.1)

--- a/package.json
+++ b/package.json
@@ -234,9 +234,6 @@
     "@folio/plugin-find-organization": "^3.3.0",
     "@folio/plugin-find-po-line": "^3.3.0"
   },
-  "resolutions": {
-    "@rehooks/local-storage": "2.4.0"
-  },
   "peerDependencies": {
     "@folio/stripes": "^8.0.0",
     "react": "^17.0.2",


### PR DESCRIPTION
`@rehooks/local-storage` is no longer broken so we can once again depend on the latest version of it, allowing us to remove `resolutions` entries for it that are scattered about.

Attn @NikitaSedyx I don't have commit privileges in this repository so if this PR looks good to you please merge it. Thanks!

Refs [UIREC-259](https://issues.folio.org/browse/UIREC-259)
