### PR TITLE
UIREC-270: Also support circulation 14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## (IN PROGRESS)
 
 * Unpin `@rehooks/local-storage` now that it's no longer broken. Refs UIREC-259.
+* Also support `circulation` `14.0`. Refs UIREC-270.
 
 ## [3.0.0](https://github.com/folio-org/ui-receiving/tree/v3.0.0) (2023-02-22)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v2.3.1...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "home": "/receiving",
     "okapiInterfaces": {
       "acquisitions-units": "1.1",
-      "circulation": "9.5 10.0 11.0 12.0 13.0",
+      "circulation": "9.5 10.0 11.0 12.0 13.0 14.0",
       "configuration": "2.0",
       "contributor-types": "2.0",
       "holdings-storage": "4.2 5.0 6.0",

--- a/src/ReceivingList/ReceivingList.test.js
+++ b/src/ReceivingList/ReceivingList.test.js
@@ -23,7 +23,7 @@ jest.mock('@folio/stripes/smart-components', () => ({
   PersistedPaneset: (props) => <div>{props.children}</div>,
 }));
 
-jest.mock('react-virtualized-auto-sizer/dist/index.cjs', () => {
+jest.mock('react-virtualized-auto-sizer', () => {
   return (props) => {
     const renderCallback = props.children;
 


### PR DESCRIPTION
## Purpose
Also support circulation 14.0

## Approach
Field fulfilmentPreference was renamed to fulfillmentPreference. This changes do not affect current module.

## Refs
https://issues.folio.org/browse/UIREC-270