### PR TITLE
UIREC-294 Check if a holding exists during the abandonment check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * *BREAKING* Upgrade React to v18. Refs UIREC-280.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UIREC-286.
 * Bump optional plugins to their `@folio/stripes` `v9` compatible versions. Refs UIREC-290.
+* Check if a holding exists during the abandonment check. Refs UIREC-294.
 
 ## [3.0.0](https://github.com/folio-org/ui-receiving/tree/v3.0.0) (2023-02-22)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v2.3.1...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -218,9 +218,9 @@
     "react-router-prop-types": "^1.0.4"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-instance": "^7.0.0",
-    "@folio/plugin-find-organization": "^5.0.0",
-    "@folio/plugin-find-po-line": "^5.0.0"
+    "@folio/plugin-find-instance": "^6.3.0",
+    "@folio/plugin-find-organization": "^4.0.0",
+    "@folio/plugin-find-po-line": "^4.0.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -218,9 +218,9 @@
     "react-router-prop-types": "^1.0.4"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-instance": "^6.3.0",
-    "@folio/plugin-find-organization": "^4.0.0",
-    "@folio/plugin-find-po-line": "^4.0.0"
+    "@folio/plugin-find-instance": "^7.0.0",
+    "@folio/plugin-find-organization": "^5.0.0",
+    "@folio/plugin-find-po-line": "^5.0.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^9.0.0",

--- a/src/TitleDetails/AddPieceModal/AddPieceModal.test.js
+++ b/src/TitleDetails/AddPieceModal/AddPieceModal.test.js
@@ -2,7 +2,6 @@ import { MemoryRouter } from 'react-router-dom';
 
 import user from '@folio/jest-config-stripes/testing-library/user-event';
 import { act, render, screen } from '@folio/jest-config-stripes/testing-library/react';
-
 import { useOkapiKy } from '@folio/stripes/core';
 import {
   FieldInventory,

--- a/src/TitleDetails/AddPieceModal/AddPieceModal.test.js
+++ b/src/TitleDetails/AddPieceModal/AddPieceModal.test.js
@@ -68,7 +68,7 @@ const findButton = (name) => screen.findByRole('button', { name });
 
 const createNewHoldingForThePiece = (newHoldingId = 'newHoldingUUID') => {
   return act(async () => FieldInventory.mock.calls[0][0].onChange(null, 'locationId', 'holdingId', newHoldingId));
-}
+};
 
 describe('AddPieceModal', () => {
   beforeEach(() => {
@@ -76,7 +76,7 @@ describe('AddPieceModal', () => {
     defaultProps.onCheckIn.mockClear();
     defaultProps.onSubmit.mockClear();
     defaultProps.getHoldingsItemsAndPieces.mockClear();
-    FieldInventory.mockClear()
+    FieldInventory.mockClear();
     kyMock.get.mockClear();
     useOkapiKy.mockClear().mockReturnValue(kyMock);
   });
@@ -150,7 +150,7 @@ describe('AddPieceModal', () => {
           pieces: { totalRecords: 1 },
           items: { totalRecords: 0 },
         });
-        
+
         renderAddPieceModal({
           ...defaultProps,
           initialValues: {
@@ -159,17 +159,17 @@ describe('AddPieceModal', () => {
             holdingId: holding.id,
           },
         });
-    
+
         await createNewHoldingForThePiece();
         await user.click(await findButton('ui-receiving.piece.actions.saveAndClose'));
-    
+
         expect(await screen.findByText('ui-receiving.piece.actions.edit.deleteHoldings.message')).toBeInTheDocument();
         expect(defaultProps.onSubmit).not.toHaveBeenCalled();
       });
-    
+
       it('should NOT display the modal for deleting abandoned holding if it has already been deleted', async () => {
         kyMock.get.mockReturnValue(({ json: () => Promise.reject(new Error('404')) }));
-    
+
         renderAddPieceModal({
           ...defaultProps,
           initialValues: {
@@ -178,10 +178,10 @@ describe('AddPieceModal', () => {
             holdingId: holding.id,
           },
         });
-    
+
         await createNewHoldingForThePiece();
         await user.click(await findButton('ui-receiving.piece.actions.saveAndClose'));
-    
+
         expect(screen.queryByText('ui-receiving.piece.actions.edit.deleteHoldings.message')).not.toBeInTheDocument();
         expect(defaultProps.onSubmit).toHaveBeenCalled();
       });
@@ -194,7 +194,7 @@ describe('AddPieceModal', () => {
         ...defaultProps,
         initialValues: { isCreateAnother: true },
       });
-      
+
       const saveBtn = await findButton('ui-receiving.piece.actions.quickReceive');
       const quickReceiveBtn = await findButton('ui-receiving.piece.actions.quickReceive');
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIREC-294

When a holding of a piece changes, a check is made to see if the current holding has connections with other items and/or pieces. The absence of links to the current holding implies a proposal to the user to delete or keep this holding. However, it may already have been deleted (as evidenced by the "invalid reference" label), so making additional checks to ensure that it will be abandoned is meaningless.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Check if a holding exists before analyzing if it will be abandoned after changing a piece holding.

## Screenshots

https://github.com/folio-org/ui-receiving/assets/88109087/b38e8d2b-9396-4191-85ac-ca8ca41006c9


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
