### PR TITLE
UIREC-290 bump optional plugins to compatible versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Upgrade `Node.js` to `18` version in GitHub Actions. Refs UIREC-281.
 * *BREAKING* Upgrade React to v18. Refs UIREC-280.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UIREC-286.
+* Bump optional plugins to their `@folio/stripes` `v9` compatible versions. Refs UIREC-290.
 
 ## [3.0.0](https://github.com/folio-org/ui-receiving/tree/v3.0.0) (2023-02-22)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v2.3.1...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -218,9 +218,9 @@
     "react-router-prop-types": "^1.0.4"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-instance": "^6.3.0",
-    "@folio/plugin-find-organization": "^4.0.0",
-    "@folio/plugin-find-po-line": "^4.0.0"
+    "@folio/plugin-find-instance": "^7.0.0",
+    "@folio/plugin-find-organization": "^5.0.0",
+    "@folio/plugin-find-po-line": "^5.0.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^9.0.0",


### PR DESCRIPTION
Use plugins compatible with the requested version of stripes (v9).

Refs [UIREC-290](https://issues.folio.org/browse/UIREC-290)