### PR TITLE
UIREC-288 Display and edit claiming active and interval fields in receiving title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.1.0 (IN PROGRESS)
 * Include Accession number field in receive all view. Refs UIREC-285.
+* Display and edit claiming active and interval fields in receiving title. Refs UIREC-288.
 
 ## [4.0.0](https://github.com/folio-org/ui-receiving/tree/v4.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v3.0.0...v4.0.0)

--- a/src/TitleDetails/TitleDetails.js
+++ b/src/TitleDetails/TitleDetails.js
@@ -408,6 +408,8 @@ const TitleDetails = ({
             >
               <ViewMetaData metadata={title.metadata} />
               <TitleInformation
+                claimingActive={title.claimingActive}
+                claimingInterval={title.claimingInterval}
                 contributors={title.contributors}
                 edition={title.edition}
                 productIds={title.productIds}

--- a/src/TitleDetails/TitleInformation/TitleInformation.js
+++ b/src/TitleDetails/TitleInformation/TitleInformation.js
@@ -1,8 +1,8 @@
-import React from 'react';
-import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 
 import {
+  Checkbox,
   Col,
   KeyValue,
   NoValue,
@@ -16,6 +16,8 @@ import {
 } from '@folio/stripes-acq-components';
 
 const TitleInformation = ({
+  claimingActive,
+  claimingInterval,
   contributors,
   edition,
   productIds,
@@ -88,6 +90,26 @@ const TitleInformation = ({
             value={subscriptionInterval ?? <NoValue />}
           />
         </Col>
+        <Col
+          xs={6}
+          md={3}
+        >
+          <Checkbox
+            checked={claimingActive}
+            disabled
+            label={<FormattedMessage id="ui-receiving.title.claimingActive" />}
+            vertical
+          />
+        </Col>
+        <Col
+          xs={6}
+          md={3}
+        >
+          <KeyValue
+            label={<FormattedMessage id="ui-receiving.title.claimingInterval" />}
+            value={claimingInterval}
+          />
+        </Col>
       </Row>
       <Row>
         <Col
@@ -114,6 +136,8 @@ const TitleInformation = ({
 };
 
 TitleInformation.propTypes = {
+  claimingActive: PropTypes.bool,
+  claimingInterval: PropTypes.number,
   contributors: PropTypes.arrayOf(PropTypes.object),
   edition: PropTypes.string,
   productIds: PropTypes.arrayOf(PropTypes.object),

--- a/src/TitleDetails/TitleInformation/TitleInformation.test.js
+++ b/src/TitleDetails/TitleInformation/TitleInformation.test.js
@@ -1,9 +1,7 @@
-import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
-import { render, cleanup } from '@folio/jest-config-stripes/testing-library/react';
 import { IntlProvider } from 'react-intl';
+import { MemoryRouter } from 'react-router-dom';
 
-import '@folio/stripes-acq-components/test/jest/__mock__';
+import { render, cleanup } from '@folio/jest-config-stripes/testing-library/react';
 
 import TitleInformation from './TitleInformation';
 
@@ -11,6 +9,8 @@ const renderTitleInformation = (titleProp) => (render(
   <IntlProvider locale="en">
     <MemoryRouter>
       <TitleInformation
+        claimingActive={titleProp.claimingActive}
+        claimingInterval={titleProp.claimingInterval}
         contributors={titleProp.contributors}
         edition={titleProp.edition}
         productIds={titleProp.productIds}
@@ -25,6 +25,8 @@ const renderTitleInformation = (titleProp) => (render(
 ));
 
 const title = {
+  claimingActive: true,
+  claimingInterval: 42,
   contributors: [],
   edition: 'First edition',
   productIds: [],
@@ -47,5 +49,7 @@ describe('Given Title information', () => {
     expect(getByText(title.subscriptionFrom)).toBeDefined();
     expect(getByText(title.subscriptionInterval.toString())).toBeDefined();
     expect(getByText(title.subscriptionTo)).toBeDefined();
+    expect(getByText('ui-receiving.title.claimingActive')).toBeInTheDocument();
+    expect(getByText(title.claimingInterval)).toBeInTheDocument();
   });
 });

--- a/src/TitleForm/TitleForm.js
+++ b/src/TitleForm/TitleForm.js
@@ -1,8 +1,8 @@
-import React, { useRef } from 'react';
+import get from 'lodash/get';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { useCallback, useRef } from 'react';
 import { Field } from 'react-final-form';
-import { get } from 'lodash';
+import { FormattedMessage } from 'react-intl';
 import { useHistory } from 'react-router';
 
 import stripesFinalForm from '@folio/stripes/final-form';
@@ -55,6 +55,7 @@ const TitleForm = ({
 }) => {
   const history = useHistory();
   const accordionStatusRef = useRef();
+  const { change } = form;
   const initialValues = get(form.getState(), 'initialValues', {});
   const { id, title, metadata } = initialValues;
   const paneFooter = (
@@ -75,6 +76,14 @@ const TitleForm = ({
   const addInstance = form.mutators.setTitleValue;
   const addLines = form.mutators.setPOLine;
   const { details, physical, isPackage } = get(values, 'poLine', {});
+
+  const onClaimingActiveChange = useCallback((event) => {
+    const { target: { checked } } = event;
+
+    change('claimingActive', checked);
+
+    if (!checked) change('claimingInterval', undefined);
+  }, [change]);
 
   const shortcuts = [
     {
@@ -223,6 +232,40 @@ const TitleForm = ({
                           />
                         </Col>
                       </Row>
+
+                      <Row>
+                        <Col
+                          xs={6}
+                          md={3}
+                        >
+                          <Field
+                            component={Checkbox}
+                            fullWidth
+                            label={<FormattedMessage id="ui-receiving.title.claimingActive" />}
+                            onChange={onClaimingActiveChange}
+                            name="claimingActive"
+                            type="checkbox"
+                            vertical
+                            validateFields={[]}
+                          />
+                        </Col>
+
+                        <Col
+                          xs={6}
+                          md={3}
+                        >
+                          <Field
+                            label={<FormattedMessage id="ui-receiving.title.claimingInterval" />}
+                            name="claimingInterval"
+                            component={TextField}
+                            type="number"
+                            fullWidth
+                            disabled={!values.claimingActive}
+                            validateFields={[]}
+                          />
+                        </Col>
+                      </Row>
+
                       <Row>
                         <Col xs={12}>
                           <ContributorsForm contributorNameTypes={contributorNameTypes} />

--- a/src/TitleForm/TitleForm.test.js
+++ b/src/TitleForm/TitleForm.test.js
@@ -1,8 +1,7 @@
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { useHistory } from 'react-router';
-import { Form } from 'react-final-form';
-import { render } from '@folio/jest-config-stripes/testing-library/react';
+
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 import user from '@folio/jest-config-stripes/testing-library/user-event';
 
 import {
@@ -25,24 +24,16 @@ jest.mock('react-router', () => ({
 
 const defaultProps = {
   onCancel: jest.fn(),
-  form: {},
   onSubmit: jest.fn(),
-  pristine: false,
-  submitting: false,
   initialValues: { metadata: {} },
 };
 
-const renderTitleForm = (props = defaultProps) => (render(
-  <Form
-    onSubmit={jest.fn}
-    render={() => (
-      <TitleForm
-        {...props}
-      />
-    )}
+const renderTitleForm = (props = defaultProps) => render(
+  <TitleForm
+    {...props}
   />,
   { wrapper: MemoryRouter },
-));
+);
 
 describe('TitleForm', () => {
   it('should display title', () => {
@@ -62,6 +53,24 @@ describe('TitleForm', () => {
 
     expect(getByText('stripes-acq-components.FormFooter.cancel')).toBeDefined();
     expect(getByText('stripes-acq-components.FormFooter.save')).toBeDefined();
+  });
+
+  it('should clear the \'Claiming interval\' field when a user unchecked \'Claiming active\' checkbox', async () => {
+    renderTitleForm();
+
+    const claimingActiveField = screen.getByRole('checkbox', { name: 'ui-receiving.title.claimingActive' });
+    const claimingIntervalField = screen.getByLabelText('ui-receiving.title.claimingInterval');
+
+    await user.click(claimingActiveField);
+    await user.type(claimingIntervalField, '42');
+
+    expect(claimingActiveField).toBeChecked();
+    expect(claimingIntervalField).toHaveValue(42);
+
+    await user.click(claimingActiveField);
+
+    expect(claimingActiveField).not.toBeChecked();
+    expect(claimingIntervalField).toHaveValue(null);
   });
 
   describe('Close form', () => {

--- a/translations/ui-receiving/en.json
+++ b/translations/ui-receiving/en.json
@@ -95,6 +95,8 @@
   "title.receivingWorkflow": "Receiving workflow",
   "title.receivingWorkflow.independent": "Independent order and receipt quantity",
   "title.receivingWorkflow.synchronized": "Synchronized order and receipt quantity",
+  "title.claimingActive": "Claiming active",
+  "title.claimingInterval": "Claiming interval",
   "title.contributors.add": "Add contributor",
   "title.contributors.contributor": "Contributor",
   "title.contributors.contributorType": "Contributor ID type",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIREC-288

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Add components for viewing and editing the "Claiming active" and "Claiming interval" fields in PO Line details.

## Screenshot

https://github.com/folio-org/ui-receiving/assets/88109087/f744a01c-75ab-468a-90c9-4f7d7bcfde9e



## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
