### PR TITLE
UIREC-295 Add the 'Acquisition units' field to the receiving title form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Add validation for the `claimingInterval` field. Refs UIREC-308.
 * View piece status change log. Refs UIREC-305.
 * Add CSV export options for new piece statuses. Refs UIREC-306.
-* Add the "Acquisition units" field to the receiving title form. Refs UIREC-295.
+* Add the "Acquisition units" protected field to the receiving title form. Refs UIREC-295.
 
 ## [4.0.0](https://github.com/folio-org/ui-receiving/tree/v4.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v3.0.0...v4.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add validation for the `claimingInterval` field. Refs UIREC-308.
 * View piece status change log. Refs UIREC-305.
 * Add CSV export options for new piece statuses. Refs UIREC-306.
+* Add the "Acquisition units" field to the receiving title form. Refs UIREC-295.
 
 ## [4.0.0](https://github.com/folio-org/ui-receiving/tree/v4.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v3.0.0...v4.0.0)

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
       },
       {
         "permissionName": "ui-receiving.acq-units.assignment.manage",
-        "displayName": "Receiving: Manage acquisition units of existing receiving title",
+        "displayName": "Receiving: Manage acquisition units",
         "visible": true,
         "subPermissions": [
           "titles.acquisitions-units-assignments.manage"

--- a/package.json
+++ b/package.json
@@ -157,6 +157,24 @@
         ]
       },
       {
+        "permissionName": "ui-receiving.acq-units.assignment.assign",
+        "displayName": "Receiving: Assign acquisition units to new receiving title",
+        "description": "",
+        "visible": true,
+        "subPermissions": [
+          "titles.acquisitions-units-assignments.assign"
+        ]
+      },
+      {
+        "permissionName": "ui-receiving.acq-units.assignment.manage",
+        "displayName": "Receiving: Manage acquisition units of existing receiving title",
+        "description": "",
+        "visible": true,
+        "subPermissions": [
+          "titles.acquisitions-units-assignments.manage"
+        ]
+      },
+      {
         "permissionName": "ui-receiving.exportCSV",
         "displayName": "Receiving: Export search results",
         "description": "",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,6 @@
       {
         "permissionName": "ui-receiving.acq-units.assignment.assign",
         "displayName": "Receiving: Assign acquisition units to new receiving title",
-        "description": "",
         "visible": true,
         "subPermissions": [
           "titles.acquisitions-units-assignments.assign"
@@ -168,7 +167,6 @@
       {
         "permissionName": "ui-receiving.acq-units.assignment.manage",
         "displayName": "Receiving: Manage acquisition units of existing receiving title",
-        "description": "",
         "visible": true,
         "subPermissions": [
           "titles.acquisitions-units-assignments.manage"

--- a/src/TitleForm/TitleForm.js
+++ b/src/TitleForm/TitleForm.js
@@ -27,6 +27,7 @@ import {
 import { Pluggable } from '@folio/stripes/core';
 import { ViewMetaData } from '@folio/stripes/smart-components';
 import {
+  AcqUnitsField,
   FieldDatepickerFinal,
   FolioFormattedDate,
   FormFooter,
@@ -42,6 +43,8 @@ import ProductIdDetailsForm from './ProductIdDetailsForm';
 import ContributorsForm from './ContributorsForm';
 
 const ALLOWED_YEAR_LENGTH = 4;
+const ASSIGN_ACQ_UNITS_PERM = 'titles.acquisitions-units-assignments.assign';
+const MANAGE_ACQ_UNITS_PERM = 'titles.acquisitions-units-assignments.manage';
 
 const validateClaimingInterval = (value, { claimingActive }) => {
   if (!claimingActive) return undefined;
@@ -273,6 +276,19 @@ const TitleForm = ({
                             required={isClaimingActive}
                             validate={validateClaimingInterval}
                             validateFields={[]}
+                          />
+                        </Col>
+                        <Col
+                          xs={6}
+                          md={3}
+                        >
+                          <AcqUnitsField
+                            id="title-acq-units"
+                            name="acqUnitIds"
+                            perm={isEditMode ? MANAGE_ACQ_UNITS_PERM : ASSIGN_ACQ_UNITS_PERM}
+                            isEdit={isEditMode}
+                            preselectedUnits={values.acqUnitIds}
+                            isFinal
                           />
                         </Col>
                       </Row>

--- a/translations/ui-receiving/en.json
+++ b/translations/ui-receiving/en.json
@@ -237,5 +237,7 @@
   "permission.edit": "Receiving: View, edit",
   "permission.create": "Receiving: View, edit, create",
   "permission.delete": "Receiving: View, edit, delete",
+  "permission.acq-units.assignment.assign": "Receiving: Assign acquisition units to new receiving title",
+  "permission.acq-units.assignment.manage": "Receiving: Manage acquisition units of existing receiving title",
   "permission.exportCSV": "Receiving: Export search results"
 }

--- a/translations/ui-receiving/en.json
+++ b/translations/ui-receiving/en.json
@@ -238,6 +238,6 @@
   "permission.create": "Receiving: View, edit, create",
   "permission.delete": "Receiving: View, edit, delete",
   "permission.acq-units.assignment.assign": "Receiving: Assign acquisition units to new receiving title",
-  "permission.acq-units.assignment.manage": "Receiving: Manage acquisition units of existing receiving title",
+  "permission.acq-units.assignment.manage": "Receiving: Manage acquisition units",
   "permission.exportCSV": "Receiving: Export search results"
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIREC-295

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Add `<AcqUnitsField />` to the title from and introduce permission sets to assign and manage acq units.

## Screenshot

https://github.com/folio-org/ui-receiving/assets/88109087/c70a7958-0a26-402a-ad7b-a710d0fe6e57


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
