### PR TITLE
UIREC-292 Provide independent 'disabled' status for piece actions

### DIFF
--- a/src/TitleDetails/AddPieceModal/AddPieceModal.js
+++ b/src/TitleDetails/AddPieceModal/AddPieceModal.js
@@ -101,8 +101,8 @@ const AddPieceModal = ({
   } = formValues;
 
   /*
-    When "saveAndCreate" action is triggered, `isCreateAnother` is passed as initial value to apply validations.
-    This param should be reseted to `false` after the component init.
+    When the "saveAndCreate" action is triggered, `isCreateAnother` is passed as an initial value to apply validations.
+    This param should be reset to `false` after the component init.
   */
   useEffect(() => {
     change('isCreateAnother', false);

--- a/src/TitleDetails/AddPieceModal/AddPieceModal.js
+++ b/src/TitleDetails/AddPieceModal/AddPieceModal.js
@@ -59,6 +59,7 @@ import { DeletePieceModal } from '../DeletePieceModal';
 import { DeleteHoldingsModal } from '../DeleteHoldingsModal';
 import { SendClaimModal } from '../SendClaimModal';
 import { ModalActionButtons } from './ModalActionButtons';
+import { PIECE_ACTION_NAMES } from './ModalActionButtons/constants';
 import { ReceivingStatusChangeLog } from './ReceivingStatusChangeLog';
 
 const AddPieceModal = ({
@@ -67,7 +68,6 @@ const AddPieceModal = ({
   deletePiece,
   canDeletePiece,
   form,
-  initialValues,
   handleSubmit,
   hasValidationErrors,
   pristine,
@@ -115,7 +115,7 @@ const AddPieceModal = ({
 
   const initialHoldingId = useMemo(() => getState().initialValues?.holdingId, [getState]);
 
-  const disabled = (initialValues.isCreateAnother && pristine) || hasValidationErrors;
+  const isSaveDisabled = (id && pristine) || hasValidationErrors;
 
   const onReceive = useCallback(
     () => {
@@ -196,6 +196,12 @@ const AddPieceModal = ({
     onStatusChange(PIECE_STATUS.claimSent);
   }, [batch, change, onStatusChange]);
 
+  const actionsDisabled = {
+    [PIECE_ACTION_NAMES.saveAndClose]: isSaveDisabled,
+    [PIECE_ACTION_NAMES.saveAndCreate]: isSaveDisabled,
+    [PIECE_ACTION_NAMES.delete]: !canDeletePiece,
+  };
+
   const start = (
     <Button
       data-test-add-piece-cancel
@@ -207,8 +213,7 @@ const AddPieceModal = ({
   );
   const end = (
     <ModalActionButtons
-      canDeletePiece={canDeletePiece}
-      disabled={disabled}
+      actionsDisabled={actionsDisabled}
       isCreateAnother={isCreateAnother}
       isEditMode={Boolean(id)}
       onCreateAnotherPiece={onCreateAnotherPiece}
@@ -237,18 +242,18 @@ const AddPieceModal = ({
     },
     {
       name: 'save',
-      handler: handleKeyCommand(onSave, { disabled }),
+      handler: handleKeyCommand(onSave, { disabled: isSaveDisabled }),
     },
     {
       name: 'receive',
       shortcut: 'mod + alt + r',
-      handler: handleKeyCommand(onReceive, { disabled }),
+      handler: handleKeyCommand(onReceive),
     },
     {
       name: 'saveAndCreateAnother',
       shortcut: 'alt + s',
       handler: handleKeyCommand(onCreateAnotherPiece, {
-        disabled: disabled || !stripes.hasPerm('ui-receiving.create'),
+        disabled: isSaveDisabled || !stripes.hasPerm('ui-receiving.create'),
       }),
     },
     {
@@ -532,7 +537,6 @@ AddPieceModal.propTypes = {
   locations: PropTypes.arrayOf(PropTypes.object),
   poLine: PropTypes.object.isRequired,
   getHoldingsItemsAndPieces: PropTypes.func.isRequired,
-  initialValues: PropTypes.object.isRequired,
   pristine: PropTypes.bool.isRequired,
 };
 

--- a/src/TitleDetails/AddPieceModal/ModalActionButtons/ModalActionButtons.js
+++ b/src/TitleDetails/AddPieceModal/ModalActionButtons/ModalActionButtons.js
@@ -9,13 +9,14 @@ import {
 } from '@folio/stripes/components';
 import { PIECE_STATUS } from '@folio/stripes-acq-components';
 
+import { PIECE_ACTION_NAMES } from './constants';
 import { getPieceActionMenu } from './utils';
 
 import css from './ModalActionButtons.css';
 
 export const ModalActionButtons = ({
+  actionsDisabled,
   canDeletePiece,
-  disabled,
   isEditMode,
   onClaimDelay,
   onClaimSend,
@@ -27,8 +28,8 @@ export const ModalActionButtons = ({
   status,
 }) => {
   const actionMenu = getPieceActionMenu({
+    actionsDisabled,
     canDeletePiece,
-    disabled,
     isEditMode,
     onClaimDelay,
     onClaimSend,
@@ -39,13 +40,14 @@ export const ModalActionButtons = ({
     status,
   });
   const saveButtonLabelId = 'ui-receiving.piece.actions.saveAndClose';
+  const isSaveDisabled = actionsDisabled[PIECE_ACTION_NAMES.saveAndClose];
 
   if (actionMenu.length === 0) {
     return (
       <Button
         buttonStyle="primary"
         data-test-add-piece-save
-        disabled={disabled}
+        disabled={isSaveDisabled}
         onClick={onSave}
         marginBottom0
       >
@@ -59,7 +61,7 @@ export const ModalActionButtons = ({
       <Button
         buttonStyle="primary"
         data-test-add-piece-save
-        disabled={disabled}
+        disabled={isSaveDisabled}
         onClick={onSave}
         marginBottom0
         buttonClass={css.saveButton}
@@ -83,8 +85,8 @@ export const ModalActionButtons = ({
 };
 
 ModalActionButtons.propTypes = {
+  actionsDisabled: PropTypes.objectOf(PropTypes.bool),
   canDeletePiece: PropTypes.bool,
-  disabled: PropTypes.bool,
   isEditMode: PropTypes.bool.isRequired,
   onClaimDelay: PropTypes.func.isRequired,
   onClaimSend: PropTypes.func.isRequired,
@@ -97,7 +99,7 @@ ModalActionButtons.propTypes = {
 };
 
 ModalActionButtons.defaultProps = {
+  actionsDisabled: {},
   canDeletePiece: false,
-  disabled: false,
   status: PIECE_STATUS.expected,
 };

--- a/src/TitleDetails/AddPieceModal/ModalActionButtons/constants.js
+++ b/src/TitleDetails/AddPieceModal/ModalActionButtons/constants.js
@@ -45,7 +45,7 @@ export const PIECE_ACTIONS_BY_STATUS = {
 };
 
 export const PIECE_ACTIONS = ({
-  actionsDisabled,
+  actionsDisabled = {},
   isEditMode,
   onClaimDelay,
   onClaimSend,

--- a/src/TitleDetails/AddPieceModal/ModalActionButtons/constants.js
+++ b/src/TitleDetails/AddPieceModal/ModalActionButtons/constants.js
@@ -7,6 +7,7 @@ import {
 import { PIECE_STATUS } from '@folio/stripes-acq-components';
 
 export const PIECE_ACTION_NAMES = {
+  saveAndClose: 'saveAndClose',
   saveAndCreate: 'saveAndCreate',
   quickReceive: 'quickReceive',
   sendClaim: 'sendClaim',
@@ -44,8 +45,7 @@ export const PIECE_ACTIONS_BY_STATUS = {
 };
 
 export const PIECE_ACTIONS = ({
-  canDeletePiece,
-  disabled,
+  actionsDisabled,
   isEditMode,
   onClaimDelay,
   onClaimSend,
@@ -56,7 +56,7 @@ export const PIECE_ACTIONS = ({
 }) => ({
   delayClaim: (
     <Button
-      disabled={disabled}
+      disabled={actionsDisabled[PIECE_ACTION_NAMES.delayClaim]}
       buttonStyle="dropdownItem"
       data-testid="delay-claim-button"
       onClick={onClaimDelay}
@@ -71,7 +71,7 @@ export const PIECE_ACTIONS = ({
       onClick={onDelete}
       buttonStyle="dropdownItem"
       data-testid="delete-piece-button"
-      disabled={!canDeletePiece || disabled}
+      disabled={actionsDisabled[PIECE_ACTION_NAMES.delete]}
     >
       <Icon icon="trash">
         <FormattedMessage id="ui-receiving.piece.action.button.delete" />
@@ -80,7 +80,7 @@ export const PIECE_ACTIONS = ({
   ) : null,
   expect: (
     <Button
-      disabled={disabled}
+      disabled={actionsDisabled[PIECE_ACTION_NAMES.expect]}
       buttonStyle="dropdownItem"
       data-testid="expect-piece-button"
       onClick={() => onStatusChange(PIECE_STATUS.expected)}
@@ -92,7 +92,7 @@ export const PIECE_ACTIONS = ({
   ),
   quickReceive: (
     <Button
-      disabled={disabled}
+      disabled={actionsDisabled[PIECE_ACTION_NAMES.quickReceive]}
       data-testid="quickReceive"
       buttonStyle="dropdownItem"
       onClick={onReceive}
@@ -104,7 +104,7 @@ export const PIECE_ACTIONS = ({
   ),
   saveAndCreate: (
     <Button
-      disabled={disabled}
+      disabled={actionsDisabled[PIECE_ACTION_NAMES.saveAndCreate]}
       buttonStyle="dropdownItem"
       data-testid="create-another-piece-button"
       onClick={onCreateAnotherPiece}
@@ -116,7 +116,7 @@ export const PIECE_ACTIONS = ({
   ),
   sendClaim: (
     <Button
-      disabled={disabled}
+      disabled={actionsDisabled[PIECE_ACTION_NAMES.sendClaim]}
       buttonStyle="dropdownItem"
       data-testid="send-claim-button"
       onClick={onClaimSend}
@@ -128,7 +128,7 @@ export const PIECE_ACTIONS = ({
   ),
   unReceive: (
     <Button
-      disabled={disabled}
+      disabled={actionsDisabled[PIECE_ACTION_NAMES.unReceive]}
       buttonStyle="dropdownItem"
       data-testid="unReceive-piece-button"
       onClick={() => onStatusChange(PIECE_STATUS.expected)}
@@ -140,7 +140,7 @@ export const PIECE_ACTIONS = ({
   ),
   unReceivable: (
     <Button
-      disabled={disabled}
+      disabled={actionsDisabled[PIECE_ACTION_NAMES.unReceivable]}
       buttonStyle="dropdownItem"
       data-testid="unReceivable-piece-button"
       onClick={() => onStatusChange(PIECE_STATUS.unreceivable)}

--- a/src/TitleDetails/AddPieceModal/ModalActionButtons/utils.test.js
+++ b/src/TitleDetails/AddPieceModal/ModalActionButtons/utils.test.js
@@ -1,6 +1,9 @@
 import { PIECE_STATUS } from '@folio/stripes-acq-components';
 
-import { PIECE_ACTIONS_BY_STATUS } from './constants';
+import {
+  PIECE_ACTIONS_BY_STATUS,
+  PIECE_ACTION_NAMES,
+} from './constants';
 import { getPieceActionMenu } from './utils';
 
 const { expected, unreceivable, received } = PIECE_STATUS;
@@ -19,20 +22,24 @@ describe('getPieceActionMenus', () => {
   });
 
   it('should return array of action menus', () => {
-    const result = getPieceActionMenu({ status: expected, disabled: false });
+    const result = getPieceActionMenu({ status: expected });
 
     expect(result).toHaveLength(PIECE_ACTIONS_BY_STATUS[expected].length);
   });
 
   describe('delete action', () => {
     it('should not return `delete` action menu if `isEditMode` is false', () => {
-      const result = getPieceActionMenu({ status: expected, disabled: false, isEditMode: false });
+      const result = getPieceActionMenu({ status: expected, isEditMode: false });
 
       expect(result).toContain(null);
     });
 
-    it('should `delete` button be disabled if `canDeletePiece` is false', () => {
-      const result = getPieceActionMenu({ status: expected, disabled: false, isEditMode: true, canDeletePiece: false });
+    it('should `delete` button be disabled', () => {
+      const result = getPieceActionMenu({
+        status: expected,
+        actionsDisabled: { [PIECE_ACTION_NAMES.delete]: true },
+        isEditMode: true,
+      });
       const deleteButton = result.find(i => i.props['data-testid'] === 'delete-piece-button');
 
       expect(deleteButton.props).toEqual(expect.objectContaining({ disabled: true }));
@@ -42,7 +49,7 @@ describe('getPieceActionMenus', () => {
   describe('expect action', () => {
     it('should `onStatusChange` be called with `Expected` status value', () => {
       const onStatusChange = jest.fn();
-      const result = getPieceActionMenu({ status: unreceivable, disabled: true, onStatusChange });
+      const result = getPieceActionMenu({ status: unreceivable, onStatusChange });
       const expectButton = result.find(i => i.props['data-testid'] === 'expect-piece-button');
 
       expectButton.props.onClick();
@@ -54,7 +61,7 @@ describe('getPieceActionMenus', () => {
   describe('unReceive action', () => {
     it('should `onStatusChange` be called with `Expected` status value', () => {
       const onStatusChange = jest.fn();
-      const result = getPieceActionMenu({ status: received, disabled: false, onStatusChange });
+      const result = getPieceActionMenu({ status: received, onStatusChange });
       const receiveButton = result.find(i => i.props['data-testid'] === 'unReceive-piece-button');
 
       receiveButton.props.onClick();
@@ -66,7 +73,7 @@ describe('getPieceActionMenus', () => {
   describe('unReceivable action', () => {
     it('should `onStatusChange` be called with `Unreceivable` status value', () => {
       const onStatusChange = jest.fn();
-      const result = getPieceActionMenu({ status: expected, disabled: false, onStatusChange });
+      const result = getPieceActionMenu({ status: expected, onStatusChange });
       const receiveButton = result.find(i => i.props['data-testid'] === 'unReceivable-piece-button');
 
       receiveButton.props.onClick();

--- a/src/TitleDetails/TitleDetails.js
+++ b/src/TitleDetails/TitleDetails.js
@@ -220,6 +220,7 @@ const TitleDetails = ({
     const pieceFormValues = {
       ...omit(piece, ['id', 'itemId', 'receivingStatus', 'receivedDate']),
       isCreateItem: piece?.itemId ? true : piece?.isCreateItem,
+      isCreateAnother: true,
     };
 
     setPieceValues(pieceFormValues);

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -1,1 +1,2 @@
 import './createRange.mock';
+import './resizeObserver.mock';

--- a/test/jest/__mock__/resizeObserver.mock.js
+++ b/test/jest/__mock__/resizeObserver.mock.js
@@ -1,0 +1,5 @@
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIREC-292?focusedCommentId=200172&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-200172

Save actions are expected to be disabled until a user makes any changes to the existing piece.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Make it possible to specify separate actions as disabled.


## Screenshot

https://github.com/folio-org/ui-receiving/assets/88109087/a5f1e544-f686-42d9-b56a-b788847c6a30


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
