### PR TITLE
UIREC-304 Set field value as an empty string on the field clear

### DIFF
--- a/src/TitleDetails/SendClaimModal/SendClaimModal.js
+++ b/src/TitleDetails/SendClaimModal/SendClaimModal.js
@@ -1,3 +1,4 @@
+import identity from 'lodash/identity';
 import PropTypes from 'prop-types';
 import { Field } from 'react-final-form';
 import {
@@ -72,6 +73,7 @@ const SendClaimModal = ({
               fullWidth
               label={<FormattedMessage id="ui-receiving.piece.internalNote" />}
               name="internalNote"
+              parse={identity}
             />
           </Col>
           <Col xs>
@@ -80,6 +82,7 @@ const SendClaimModal = ({
               fullWidth
               label={<FormattedMessage id="ui-receiving.piece.externalNote" />}
               name="externalNote"
+              parse={identity}
             />
           </Col>
         </Row>


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIREC-304

When the internal/external note field is cleared on the "Send claim" dialog modal it should update piece fields.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Override the default behavior of converting `''` to `undefined` by passing an identity function.

[Final form docs](https://final-form.org/docs/react-final-form/types/FieldProps#parse)

## Screenshot

https://github.com/folio-org/ui-receiving/assets/88109087/67c33281-a600-46a2-bd3e-d5e56dac9c2f

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
