### PR TITLE
UIREC-312 Add support of new Action Date column to Piece Status change history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Delay claim action for piece record. Refs UIREC-303.
 * Send claim action for piece record. Refs UIREC-304.
 * Align the display of fields in full screen receiving view and piece edit form. Refs UIREC-296.
+* Display "Interval" column in the piece status logs. Refs UIREC-312.
 
 ## [4.0.0](https://github.com/folio-org/ui-receiving/tree/v4.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v3.0.0...v4.0.0)

--- a/src/TitleDetails/AddPieceModal/ReceivingStatusChangeLog/ReceivingStatusChangeLog.js
+++ b/src/TitleDetails/AddPieceModal/ReceivingStatusChangeLog/ReceivingStatusChangeLog.js
@@ -3,6 +3,7 @@ import { FormattedMessage } from 'react-intl';
 
 import {
   MultiColumnList,
+  NoValue,
   TextLink,
 } from '@folio/stripes/components';
 import { getFullName } from '@folio/stripes/util';
@@ -13,18 +14,21 @@ import { usePieceStatusChangeLog } from '../../hooks';
 const COLUMN_NAMES = {
   status: 'status',
   eventDate: 'eventDate',
+  interval: 'interval',
   user: 'user',
 };
 
 const COLUMN_MAPPING = {
   [COLUMN_NAMES.status]: <FormattedMessage id="ui-receiving.piece.statusChangeLog.column.status" />,
   [COLUMN_NAMES.eventDate]: <FormattedMessage id="ui-receiving.piece.statusChangeLog.column.date" />,
+  [COLUMN_NAMES.interval]: <FormattedMessage id="ui-receiving.piece.statusChangeLog.column.interval" />,
   [COLUMN_NAMES.user]: <FormattedMessage id="ui-receiving.piece.statusChangeLog.column.updatedBy" />,
 };
 
 const FORMATTER = {
   [COLUMN_NAMES.status]: item => item.receivingStatus,
   [COLUMN_NAMES.eventDate]: item => <FolioFormattedDate value={item.eventDate} />,
+  [COLUMN_NAMES.interval]: item => item.claimingInterval || <NoValue />,
   [COLUMN_NAMES.user]: item => (
     item.user
       ? <TextLink to={`/users/preview/${item.user.id}`}>{getFullName(item.user)}</TextLink>

--- a/translations/ui-receiving/en.json
+++ b/translations/ui-receiving/en.json
@@ -213,6 +213,7 @@
   "piece.request.isOpened": "Yes",
   "piece.status":"Status",
   "piece.statusChangeLog.column.date":"Date",
+  "piece.statusChangeLog.column.interval":"Interval",
   "piece.statusChangeLog.column.status":"Status change",
   "piece.statusChangeLog.column.updatedBy":"Updated by",
   "piece.supplement": "Supplement",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIREC-312

## Screenshot
![image](https://github.com/folio-org/ui-receiving/assets/88109087/5e10639d-fd38-4b63-80dc-a8a0a9878948)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
