### PR TITLE
UIREC-337 Correct the query used to fetch pieces on the receiving full-screen page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Disable title action buttons if user not part of acquisition unit. Refs UIREC-332.
 * Improve UI error when receipt fails due to duplicate item barcode. Refs UIREC-274.
 * UX Consistency > Search results > Update HTML page title with search term entered. Refs UIREC-320.
+* Correct the query used to fetch pieces on the receiving full-screen page. Refs UIREC-337.
 
 ## [4.0.0](https://github.com/folio-org/ui-receiving/tree/v4.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v3.0.0...v4.0.0)

--- a/src/TitleReceive/TitleReceiveContainer.js
+++ b/src/TitleReceive/TitleReceiveContainer.js
@@ -32,6 +32,7 @@ import {
   getReceivingPieceItemStatus,
   handleReceiveErrorResponse,
 } from '../common/utils';
+import { EXPECTED_PIECES_SEARCH_VALUE } from '../TitleDetails/constants';
 import TitleReceive from './TitleReceive';
 import OpenedRequestsModal from './OpenedRequestsModal';
 
@@ -71,7 +72,7 @@ function TitleReceiveContainer({ history, location, match, mutator }) {
   useEffect(
     () => {
       if (poLineId) {
-        const filterQuery = `titleId=${titleId} and poLineId==${poLineId} and receivingStatus==${PIECE_STATUS.expected}`;
+        const filterQuery = `titleId=${titleId} and poLineId==${poLineId} and receivingStatus==(${EXPECTED_PIECES_SEARCH_VALUE})`;
 
         mutator.pieces.GET({
           params: {

--- a/src/TitleReceive/TitleReceiveContainer.js
+++ b/src/TitleReceive/TitleReceiveContainer.js
@@ -14,7 +14,6 @@ import {
   LINES_API,
   locationsManifest,
   PIECE_FORMAT,
-  PIECE_STATUS,
   pieceResource,
   piecesResource,
   requestsResource,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

https://folio-org.atlassian.net/browse/UIREC-337

Update query to support all "expectable" statuses

## Screenshot
 

https://github.com/folio-org/ui-receiving/assets/88109087/13bbaff8-31ed-4744-8e3f-a2d4e7a8c943


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
