### PR TITLE
UIREC-358 Adjust the location filter to support filtering of receiving titles by multiple PO line locations or holdings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add "Display to public" toggle on piece form. Refs UIREC-333.
 * Add `<RoutingList>` component. Refs UIREC-328.
 * Add the "Bound" flag for the receiving piece form. Refs UIREC-263.
+* Adjust the location filter to support filtering of receiving titles by multiple PO line locations or holdings. Refs UIREC-358.
 
 ## [5.0.4](https://github.com/folio-org/ui-receiving/tree/v5.0.4) (2024-04-22)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v5.0.3...v5.0.4)

--- a/package.json
+++ b/package.json
@@ -91,8 +91,7 @@
           "tags.collection.get",
           "consortia.publications.item.get",
           "consortia.publications.item.post",
-          "consortia.publications-results.item.get",
-          "consortia.user-tenants.collection.get"
+          "consortia.publications-results.item.get"
         ]
       },
       {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
       "titles": "1.2",
       "users": "16.0"
     },
+    "optionalOkapiInterfaces": {
+      "consortia": "1.0"
+    },
     "queryResource": "query",
     "icons": [
       {
@@ -85,7 +88,11 @@
           "orders.pieces.collection.get",
           "orders.po-lines.item.get",
           "organizations.organizations.collection.get",
-          "tags.collection.get"
+          "tags.collection.get",
+          "consortia.publications.item.get",
+          "consortia.publications.item.post",
+          "consortia.publications-results.item.get",
+          "consortia.user-tenants.collection.get"
         ]
       },
       {

--- a/src/ReceivingList/ReceivingListFilter/ReceivingListFilter.js
+++ b/src/ReceivingList/ReceivingListFilter/ReceivingListFilter.js
@@ -90,7 +90,7 @@ const ReceivingListFilter = ({
 
       <LocationFilterContainer
         id={`filter-${FILTERS.LOCATION}`}
-        activeFilter={activeFilters[FILTERS.LOCATION] && activeFilters[FILTERS.LOCATION][0]}
+        activeFilter={activeFilters[FILTERS.LOCATION]}
         disabled={disabled}
         labelId="ui-receiving.filter.location"
         name={FILTERS.LOCATION}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIREC-358

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Since the filter is now a multi-select, it requires passing the current value of the filter (which is an array), not just one element from it.

Should be merged after:
- https://github.com/folio-org/stripes-acq-components/pull/775

## Screenshot

https://github.com/folio-org/ui-receiving/assets/88109087/b4cc452d-da27-4c59-b16d-1ce380723f8b


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
