### PR TITLE
UIREC-264 Add filter by 'Bound' status for the received pieces list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `<RoutingList>` component. Refs UIREC-328.
 * Add the "Bound" flag for the receiving piece form. Refs UIREC-263.
 * Adjust the location filter to support filtering of receiving titles by multiple PO line locations or holdings. Refs UIREC-358.
+* Add filter by "Bound" status for the received pieces list. Refs UIREC-264.
 
 ## [5.0.4](https://github.com/folio-org/ui-receiving/tree/v5.0.4) (2024-04-22)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v5.0.3...v5.0.4)

--- a/src/TitleDetails/TitleDetails.js
+++ b/src/TitleDetails/TitleDetails.js
@@ -55,6 +55,7 @@ import AddPieceModal from './AddPieceModal';
 import {
   EXPECTED_PIECE_COLUMN_MAPPING,
   EXPECTED_PIECES_SEARCH_VALUE,
+  MENU_FILTERS,
   ORDER_FORMAT_TO_PIECE_FORMAT,
   RECEIVED_PIECE_COLUMN_MAPPING,
   TITLE_ACCORDION,
@@ -311,7 +312,7 @@ const TitleDetails = ({
     filters: receivedPiecesFilters,
     changeSearch: changeReceivedPiecesSearch,
     searchQuery: receivedPiecesSearchQuery,
-  } = useFilters(noop);
+  } = useFilters(noop, { [MENU_FILTERS.bound]: ['false'] });
   const {
     applyFilters: applyUnreceivablePiecesFilters,
     applySearch: applyUnreceivablePiecesSearch,

--- a/src/TitleDetails/TitleDetailsActions/TitleDetailsReceivedActions.js
+++ b/src/TitleDetails/TitleDetailsActions/TitleDetailsReceivedActions.js
@@ -1,8 +1,13 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, useIntl } from 'react-intl';
+import {
+  FormattedMessage,
+  useIntl,
+} from 'react-intl';
 
-import { CheckboxFilter, ColumnManagerMenu } from '@folio/stripes/smart-components';
+import {
+  CheckboxFilter,
+  ColumnManagerMenu,
+} from '@folio/stripes/smart-components';
 import { FilterMenu } from '@folio/stripes-acq-components';
 import {
   Button,
@@ -12,6 +17,7 @@ import {
 } from '@folio/stripes/components';
 
 import {
+  BOUND_MENU_FILTER_OPTIONS,
   MENU_FILTERS,
   RECEIVED_PIECE_COLUMN_MAPPING,
   SUPPLEMENT_MENU_FILTER_OPTIONS,
@@ -60,6 +66,12 @@ export function TitleDetailsReceivedActions({
             name={`received-${MENU_FILTERS.supplement}`}
             onChange={({ values }) => applyFilters(MENU_FILTERS.supplement, values)}
             selectedValues={filters[MENU_FILTERS.supplement]}
+          />
+          <CheckboxFilter
+            dataOptions={BOUND_MENU_FILTER_OPTIONS}
+            name={`received-${MENU_FILTERS.bound}`}
+            onChange={({ values }) => applyFilters(MENU_FILTERS.bound, values)}
+            selectedValues={filters[MENU_FILTERS.bound]}
           />
         </FilterMenu>
 

--- a/src/TitleDetails/constants.js
+++ b/src/TitleDetails/constants.js
@@ -121,6 +121,7 @@ export const UNRECEIVABLE_PIECE_COLUMN_MAPPING = {
 };
 
 export const MENU_FILTERS = {
+  bound: 'isBound',
   supplement: 'supplement',
 };
 
@@ -132,6 +133,17 @@ export const SUPPLEMENT_MENU_FILTER_OPTIONS = [
   {
     value: 'false',
     label: <FormattedMessage id="ui-receiving.filter.nonSupplements" />,
+  },
+];
+
+export const BOUND_MENU_FILTER_OPTIONS = [
+  {
+    value: 'true',
+    label: <FormattedMessage id="ui-receiving.filter.bound" />,
+  },
+  {
+    value: 'false',
+    label: <FormattedMessage id="ui-receiving.filter.notBound" />,
   },
 ];
 

--- a/translations/ui-receiving/en.json
+++ b/translations/ui-receiving/en.json
@@ -62,6 +62,8 @@
   "filter.rush": "Rush",
   "filter.supplements": "Supplements",
   "filter.nonSupplements": "Non supplements",
+  "filter.bound": "Bound",
+  "filter.notBound": "Not bound",
   "filter.createdBy": "Created by",
   "filter.updatedBy": "Updated by",
   "filter.dateCreated": "Date created",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIREC-264

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Add additional checkboxes in the action menu filters for the receiving list accordion.
## Screenshot

https://github.com/folio-org/ui-receiving/assets/88109087/3b5340ed-8a7b-410d-85c0-10df0cc67c08


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
