### PR TITLE
UIREC-268: add missing template permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
           "orders.expect.collection.post",
           "orders.receiving.collection.post",
           "orders.routing-lists.collection.get",
+          "orders.routing-lists-template.item.get",
           "orders.routing-lists.item.get",
           "settings.receiving.enabled",
           "ui-receiving.basic.view",

--- a/src/TitleDetails/POLDetails/POLDetails.js
+++ b/src/TitleDetails/POLDetails/POLDetails.js
@@ -50,7 +50,7 @@ const POLDetails = ({
 
   return (
     <>
-      {routingLists.length && (
+      {Boolean(routingLists.length) && (
         <Row>
           <Col xs={12}>
             <MessageBanner type="warning">

--- a/src/TitleDetails/TitleDetails.js
+++ b/src/TitleDetails/TitleDetails.js
@@ -144,7 +144,7 @@ const TitleDetails = ({
     pieceLocationId ? [...new Set([...poLineLocationIds, pieceLocationId])] : poLineLocationIds
   ), [poLineLocationIds, pieceLocationId]);
   const numberOfPhysicalUnits = useMemo(() => {
-    return poLine?.locations?.reduce((acc, { quantityPhysical }) => acc + quantityPhysical, 0);
+    return poLine?.locations?.reduce((acc, { quantityPhysical = 0 }) => acc + quantityPhysical, 0);
   }, [poLine?.locations]);
   const vendor = vendorsMap[order.vendor];
   const accessProvider = vendorsMap[poLine?.eresource?.accessProvider];


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
[UIREC-268:](https://folio-org.atlassian.net/browse/UIREC-268?focusedCommentId=214069) add missing `orders.routing-lists-template.item.get` template permission 
