### PR TITLE
UIREC-365   Add Affiliation dropdown to Piece form and fullscreen receiving view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-receiving
 
-## 5.1.0 (IN PROGRESS)
+## 6.0.0 (IN PROGRESS)
 
 * UX Consistency: Update HTML Page Title display when third pane (detail record) displays. Refs UIREC-319.
 * Add "Display to public" toggle on piece form. Refs UIREC-333.
@@ -15,6 +15,7 @@
 * Add full screen Bind items page. Refs UIREC-321.
 * Implement binding button behavior. Refs UIREC-353.
 * Transfer requests for items to be bound. Refs UIREC-354.
+* *BREAKING* ECS - Add the affiliation dropdown to the piece form and full-screen receiving view. Refs UIREC-365.
 
 ## [5.0.4](https://github.com/folio-org/ui-receiving/tree/v5.0.4) (2024-04-22)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v5.0.3...v5.0.4)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
       "nature-of-content-terms": "1.0",
       "order-lines": "2.0 3.0",
       "orders": "11.0 12.0",
+      "orders-storage.settings": "1.0",
       "organizations.organizations": "1.0",
       "pieces": "3.0",
       "receiving": "2.0",
@@ -39,7 +40,8 @@
       "users": "16.0"
     },
     "optionalOkapiInterfaces": {
-      "consortia": "1.0"
+      "consortia": "1.0",
+      "consortium-search": "1.0"
     },
     "queryResource": "query",
     "icons": [
@@ -74,6 +76,7 @@
           "acquisitions-units.units.collection.get",
           "circulation.requests.collection.get",
           "configuration.entries.collection.get",
+          "consortium-search.holdings.collection.get",
           "inventory-storage.contributor-name-types.collection.get",
           "inventory-storage.holdings.collection.get",
           "inventory-storage.holdings.item.post",
@@ -109,6 +112,8 @@
           "orders.po-lines.collection.get",
           "orders.titles.collection.get",
           "orders.titles.item.get",
+          "orders-storage.settings.collection.get",
+          "orders-storage.settings.item.get",
           "ui-receiving.third-party-services"
         ]
       },

--- a/src/Receiving.js
+++ b/src/Receiving.js
@@ -16,6 +16,7 @@ import {
 } from '@folio/stripes/components';
 import {
   AcqKeyboardShortcutsModal,
+  CentralOrderingContextProvider,
   handleKeyCommand,
   useModalToggle,
 } from '@folio/stripes-acq-components';
@@ -76,7 +77,7 @@ const Receiving = () => {
   ];
 
   return (
-    <>
+    <CentralOrderingContextProvider>
       <CommandList commands={shortcutCommands}>
         <HasCommand
           commands={shortcuts}
@@ -155,7 +156,7 @@ const Receiving = () => {
           onClose={toggleModal}
         />
       )}
-    </>
+    </CentralOrderingContextProvider>
   );
 };
 

--- a/src/TitleDetails/AddPieceModal/AddPieceModal.js
+++ b/src/TitleDetails/AddPieceModal/AddPieceModal.js
@@ -31,6 +31,7 @@ import {
   ModalFooter,
   PIECE_STATUS,
   handleKeyCommand,
+  useCentralOrderingContext,
   useModalToggle,
 } from '@folio/stripes-acq-components';
 
@@ -89,6 +90,8 @@ const AddPieceModal = ({
     metadata,
     receivingStatus,
   } = formValues;
+
+  const { isCentralOrderingEnabled } = useCentralOrderingContext();
 
   /*
     When the "saveAndCreate" action is triggered, `isCreateAnother` is passed as an initial value to apply validations.
@@ -320,6 +323,7 @@ const AddPieceModal = ({
                 label={PIECE_MODAL_ACCORDION_LABELS[PIECE_MODAL_ACCORDION.pieceDetails]}
               >
                 <PieceFields
+                  centralOrdering={isCentralOrderingEnabled}
                   createInventoryValues={createInventoryValues}
                   instanceId={instanceId}
                   locationIds={locationIds}

--- a/src/TitleDetails/AddPieceModal/AddPieceModal.test.js
+++ b/src/TitleDetails/AddPieceModal/AddPieceModal.test.js
@@ -14,6 +14,7 @@ import {
   INVENTORY_RECORDS_TYPE,
   PIECE_FORMAT,
   PIECE_STATUS,
+  useCentralOrderingContext,
 } from '@folio/stripes-acq-components';
 
 import { usePieceStatusChangeLog } from '../hooks';
@@ -23,6 +24,7 @@ jest.mock('@folio/stripes-acq-components', () => {
   return {
     ...jest.requireActual('@folio/stripes-acq-components'),
     FieldInventory: jest.fn().mockReturnValue('FieldInventory'),
+    useCentralOrderingContext: jest.fn(),
   };
 });
 jest.mock('../../common/components/LineLocationsView/LineLocationsView',
@@ -116,6 +118,9 @@ describe('AddPieceModal', () => {
     defaultProps.getHoldingsItemsAndPieces.mockClear();
     FieldInventory.mockClear();
     kyMock.get.mockClear();
+    useCentralOrderingContext
+      .mockClear()
+      .mockReturnValue({ isCentralOrderingEnabled: false });
     useOkapiKy.mockClear().mockReturnValue(kyMock);
     usePieceStatusChangeLog
       .mockClear()

--- a/src/TitleDetails/AddPieceModal/AddPieceModalContainer.test.js
+++ b/src/TitleDetails/AddPieceModal/AddPieceModalContainer.test.js
@@ -1,7 +1,11 @@
 import { IntlProvider } from 'react-intl';
 import { MemoryRouter } from 'react-router-dom';
 
-import { render, screen, fireEvent } from '@folio/jest-config-stripes/testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+} from '@folio/jest-config-stripes/testing-library/react';
 import user from '@folio/jest-config-stripes/testing-library/user-event';
 
 import { PIECE_STATUS } from '@folio/stripes-acq-components';
@@ -11,6 +15,7 @@ import AddPieceModalContainer from './AddPieceModalContainer';
 jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
   FieldInventory: jest.fn(() => 'FieldInventory'),
+  useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
 }));
 jest.mock('../../common/components/LineLocationsView/LineLocationsView',
   () => jest.fn().mockReturnValue('LineLocationsView'));

--- a/src/TitleDetails/AddPieceModal/PieceFields/PieceFields.js
+++ b/src/TitleDetails/AddPieceModal/PieceFields/PieceFields.js
@@ -11,6 +11,7 @@ import {
   TextField,
 } from '@folio/stripes/components';
 import {
+  ConsortiumFieldInventory,
   FieldDatepickerFinal,
   FieldInventory,
   FieldSelectFinal,
@@ -27,6 +28,7 @@ import css from './PieceFields.css';
 import { PIECE_FORM_FIELD_NAMES } from '../../constants';
 
 export const PieceFields = ({
+  centralOrdering = false,
   createInventoryValues,
   instanceId,
   locationIds,
@@ -44,6 +46,10 @@ export const PieceFields = ({
 
   // https://issues.folio.org/browse/UIREC-208
   const isDiscoverySuppressEnabled = false;
+
+  const FieldInventoryComponent = centralOrdering
+    ? ConsortiumFieldInventory
+    : FieldInventory;
 
   return (
     <>
@@ -268,15 +274,18 @@ export const PieceFields = ({
           md={3}
         >
           <LineLocationsView
+            centralOrdering={centralOrdering}
+            instanceId={instanceId}
             poLine={poLine}
             locations={locations}
           />
         </Col>
         <Col
-          xs={6}
-          md={3}
+          xs={centralOrdering ? 12 : 6}
+          md={centralOrdering ? 6 : 3}
         >
-          <FieldInventory
+          <FieldInventoryComponent
+            affiliationName={PIECE_FORM_FIELD_NAMES.receivingTenantId}
             instanceId={isLocationRequired ? instanceId : undefined}
             locationIds={locationIds}
             locations={locations}
@@ -293,6 +302,7 @@ export const PieceFields = ({
 };
 
 PieceFields.propTypes = {
+  centralOrdering: PropTypes.bool,
   createInventoryValues: PropTypes.object.isRequired,
   instanceId: PropTypes.string,
   locationIds: PropTypes.arrayOf(PropTypes.string).isRequired,

--- a/src/TitleDetails/TitleDetails.js
+++ b/src/TitleDetails/TitleDetails.js
@@ -82,7 +82,7 @@ import { UnreceivablePiecesList } from './UnreceivablePiecesList';
 
 import css from './TitleDetails.css';
 
-function getNewPieceValues(titleId, poLine) {
+function getNewPieceValues(titleId, poLine, centralOrdering) {
   const { orderFormat, id: poLineId, physical, locations, checkinItems } = poLine;
   const initialValuesPiece = { receiptDate: physical?.expectedReceiptDate, poLineId, titleId };
 
@@ -90,7 +90,7 @@ function getNewPieceValues(titleId, poLine) {
     initialValuesPiece.format = ORDER_FORMAT_TO_PIECE_FORMAT[orderFormat];
   }
 
-  if (locations.length === 1) {
+  if (locations.length === 1 && !centralOrdering) {
     initialValuesPiece.locationId = locations[0].locationId;
     initialValuesPiece.holdingId = locations[0].holdingId;
   }
@@ -103,6 +103,7 @@ function getNewPieceValues(titleId, poLine) {
 }
 
 const TitleDetails = ({
+  centralOrdering = false,
   deletePiece,
   history,
   location,
@@ -195,7 +196,7 @@ const TitleDetails = ({
 
   const openAddPieceModal = useCallback(
     (e, piece) => {
-      setPieceValues(piece || getNewPieceValues(title.id, poLine));
+      setPieceValues(piece || getNewPieceValues(title.id, poLine, centralOrdering));
       setConfirmAcknowledgeNote(() => toggleAddPieceModal);
 
       return (
@@ -204,7 +205,14 @@ const TitleDetails = ({
           : toggleAddPieceModal()
       );
     },
-    [poLine, title.id, title.isAcknowledged, toggleAcknowledgeNote, toggleAddPieceModal],
+    [
+      centralOrdering,
+      poLine,
+      title.id,
+      title.isAcknowledged,
+      toggleAcknowledgeNote,
+      toggleAddPieceModal,
+    ],
   );
 
   const openEditReceivedPieceModal = useCallback(
@@ -667,6 +675,7 @@ const TitleDetails = ({
 };
 
 TitleDetails.propTypes = {
+  centralOrdering: PropTypes.bool,
   deletePiece: PropTypes.func.isRequired,
   history: ReactRouterPropTypes.history.isRequired,
   location: ReactRouterPropTypes.location.isRequired,

--- a/src/TitleDetails/TitleDetails.test.js
+++ b/src/TitleDetails/TitleDetails.test.js
@@ -29,6 +29,7 @@ jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
   FieldInventory: jest.fn().mockReturnValue('FieldInventory'),
   RoutingListAccordion: jest.fn().mockReturnValue('RoutingListAccordion'),
+  useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
 }));
 jest.mock('./TitleInformation', () => jest.fn().mockReturnValue('TitleInformation'));
 jest.mock('./ReceivedPiecesList', () => jest.fn().mockReturnValue('ReceivedPiecesList'));

--- a/src/TitleDetails/TitleDetailsContainer.test.js
+++ b/src/TitleDetails/TitleDetailsContainer.test.js
@@ -3,6 +3,7 @@ import {
   QueryClient,
   QueryClientProvider,
 } from 'react-query';
+
 import {
   act,
   render,

--- a/src/TitleDetails/TitleDetailsContainer.test.js
+++ b/src/TitleDetails/TitleDetailsContainer.test.js
@@ -1,7 +1,13 @@
-import React from 'react';
-import { act, render } from '@folio/jest-config-stripes/testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+import {
+  act,
+  render,
+} from '@folio/jest-config-stripes/testing-library/react';
+import { useLocationsQuery } from '@folio/stripes-acq-components';
 
 import {
   usePieceMutator,
@@ -11,6 +17,11 @@ import {
 import TitleDetails from './TitleDetails';
 import TitleDetailsContainer from './TitleDetailsContainer';
 
+jest.mock('@folio/stripes-acq-components', () => ({
+  ...jest.requireActual('@folio/stripes-acq-components'),
+  useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
+  useLocationsQuery: jest.fn(),
+}));
 jest.mock('../common/hooks', () => ({
   usePieceMutator: jest.fn().mockReturnValue({}),
   useQuickReceive: jest.fn().mockReturnValue({}),
@@ -54,10 +65,6 @@ const mutator = {
   requests: {
     GET: jest.fn(),
   },
-  locations: {
-    GET: jest.fn().mockReturnValue(Promise.resolve(locations)),
-    reset: jest.fn(),
-  },
   vendors: {
     GET: jest.fn().mockReturnValue(Promise.resolve(vendors)),
     reset: jest.fn(),
@@ -86,6 +93,9 @@ const renderTitleDetailsContainer = () => render(
 describe('TitleDetailsContainer', () => {
   beforeEach(() => {
     TitleDetails.mockClear();
+    useLocationsQuery
+      .mockClear()
+      .mockReturnValue({ locations });
   });
 
   it('should load all data', async () => {
@@ -97,7 +107,6 @@ describe('TitleDetailsContainer', () => {
     expect(mutator.purchaseOrder.GET).toHaveBeenCalled();
     expect(mutator.pieces.GET).toHaveBeenCalled();
     expect(mutator.poLine.GET).toHaveBeenCalled();
-    expect(mutator.locations.GET).toHaveBeenCalled();
     expect(mutator.vendors.GET).toHaveBeenCalled();
   });
 

--- a/src/TitleDetails/constants.js
+++ b/src/TitleDetails/constants.js
@@ -57,6 +57,7 @@ export const PIECE_FORM_FIELD_NAMES = {
   locationId: 'locationId',
   receiptDate: 'receiptDate',
   receivingStatus: 'receivingStatus',
+  receivingTenantId: 'receivingTenantId',
   supplement: 'supplement',
 };
 

--- a/src/TitleReceive/TitleReceive.js
+++ b/src/TitleReceive/TitleReceive.js
@@ -23,6 +23,7 @@ import { TitleReceiveList } from './TitleReceiveList';
 const FIELD_NAME = 'receivedItems';
 
 const TitleReceive = ({
+  centralOrdering = false,
   createInventoryValues,
   form,
   handleSubmit,
@@ -83,6 +84,8 @@ const TitleReceive = ({
             paneTitle={paneTitle}
           >
             <LineLocationsView
+              centralOrdering={centralOrdering}
+              instanceId={instanceId}
               poLine={poLine}
               locations={locations}
             />
@@ -98,6 +101,7 @@ const TitleReceive = ({
               id="receivedItems"
               name={FIELD_NAME}
               props={{
+                centralOrdering,
                 createInventoryValues,
                 instanceId,
                 selectLocation: form.mutators.setLocationValue,
@@ -114,6 +118,7 @@ const TitleReceive = ({
 };
 
 TitleReceive.propTypes = {
+  centralOrdering: PropTypes.bool,
   createInventoryValues: PropTypes.object.isRequired,
   form: PropTypes.object,  // form object to get initialValues
   handleSubmit: PropTypes.func.isRequired,

--- a/src/TitleReceive/TitleReceiveList.js
+++ b/src/TitleReceive/TitleReceiveList.js
@@ -16,6 +16,7 @@ import {
   TextField,
 } from '@folio/stripes/components';
 import {
+  ConsortiumFieldInventory,
   FieldDatepickerFinal,
   FieldInventory,
   getItemStatusLabel,
@@ -27,6 +28,7 @@ import { CreateItemField } from '../common/components';
 import {
   PIECE_COLUMN_MAPPING,
   PIECE_COLUMNS,
+  PIECE_FORM_FIELD_NAMES,
 } from '../TitleDetails/constants';
 import { useFieldArrowNavigation } from './useFieldArrowNavigation';
 
@@ -55,6 +57,7 @@ const columnWidths = {
 };
 
 const getResultFormatter = ({
+  centralOrdering,
   createInventoryValues,
   field,
   fieldsValue,
@@ -156,8 +159,13 @@ const getResultFormatter = ({
     const locationIds = locationId ? [...new Set([...poLineLocationIds, locationId])] : poLineLocationIds;
     const isHolding = includes(createInventoryValues[record.format], INVENTORY_RECORDS_TYPE.instanceAndHolding);
 
+    const FieldInventoryComponent = centralOrdering
+      ? ConsortiumFieldInventory
+      : FieldInventory;
+
     return (
-      <FieldInventory
+      <FieldInventoryComponent
+        affiliationName={`${field}[${record.rowIndex}].${PIECE_FORM_FIELD_NAMES.receivingTenantId}`}
         instanceId={isHolding ? instanceId : undefined}
         locationIds={locationIds}
         locations={locations}
@@ -223,7 +231,15 @@ const getColumnMappings = ({ intl, isAllChecked, toggleAll }) => ({
 
 export const TitleReceiveList = ({
   fields,
-  props: { createInventoryValues, instanceId, selectLocation, toggleCheckedAll, locations, poLineLocationIds },
+  props: {
+    centralOrdering,
+    createInventoryValues,
+    instanceId,
+    selectLocation,
+    toggleCheckedAll,
+    locations,
+    poLineLocationIds,
+  },
 }) => {
   const intl = useIntl();
 
@@ -232,6 +248,7 @@ export const TitleReceiveList = ({
   const { onKeyDown: onFieldKeyDown } = useFieldArrowNavigation(field, []);
 
   const cellFormatters = useMemo(() => getResultFormatter({
+    centralOrdering,
     createInventoryValues,
     field,
     fieldsValue: fields.value,
@@ -241,6 +258,7 @@ export const TitleReceiveList = ({
     poLineLocationIds,
     selectLocation,
   }), [
+    centralOrdering,
     createInventoryValues,
     field,
     fields.value,
@@ -285,6 +303,7 @@ export const TitleReceiveList = ({
 TitleReceiveList.propTypes = {
   fields: PropTypes.object.isRequired,
   props: PropTypes.shape({
+    centralOrdering: PropTypes.bool,
     createInventoryValues: PropTypes.object.isRequired,
     instanceId: PropTypes.string,
     selectLocation: PropTypes.func.isRequired,

--- a/src/common/components/LineLocationsView/LineLocationsView.js
+++ b/src/common/components/LineLocationsView/LineLocationsView.js
@@ -1,5 +1,5 @@
-import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
+import { useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import {
@@ -8,12 +8,16 @@ import {
 } from '@folio/stripes/components';
 import {
   getHoldingLocationName,
-  useLineHoldings,
+  useInstanceHoldingsQuery,
 } from '@folio/stripes-acq-components';
 
-const LineLocationsView = ({ poLine, locations }) => {
-  const lineHoldingIds = poLine.locations.map(({ holdingId }) => holdingId).filter(Boolean);
-  const { holdings, isLoading } = useLineHoldings(lineHoldingIds);
+const LineLocationsView = ({
+  centralOrdering = false,
+  instanceId,
+  poLine,
+  locations,
+}) => {
+  const { holdings, isLoading } = useInstanceHoldingsQuery(instanceId, { consortium: centralOrdering });
 
   const locationsToDisplay = useMemo(() => {
     const locationsMap = locations.reduce((acc, l) => ({ ...acc, [l.id]: l }), {});
@@ -38,6 +42,8 @@ const LineLocationsView = ({ poLine, locations }) => {
 };
 
 LineLocationsView.propTypes = {
+  centralOrdering: PropTypes.bool,
+  instanceId: PropTypes.string,
   poLine: PropTypes.object.isRequired,
   locations: PropTypes.arrayOf(PropTypes.object).isRequired,
 };

--- a/src/common/components/LineLocationsView/LineLocationsView.test.js
+++ b/src/common/components/LineLocationsView/LineLocationsView.test.js
@@ -1,15 +1,12 @@
-import React from 'react';
 import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import { useInstanceHoldingsQuery } from '@folio/stripes-acq-components';
 
 import LineLocationsView from './LineLocationsView';
 
 jest.mock('@folio/stripes-acq-components', () => {
   return {
     ...jest.requireActual('@folio/stripes-acq-components'),
-    useLineHoldings: jest.fn().mockReturnValue({
-      isLoading: false,
-      holdings: [{ id: 'holdingId', permanentLocationId: '001' }],
-    }),
+    useInstanceHoldingsQuery: jest.fn(),
   };
 });
 
@@ -25,6 +22,15 @@ const renderLineLocationsView = (props = defaultProps) => (render(
 ));
 
 describe('LineLocationsView', () => {
+  beforeEach(() => {
+    useInstanceHoldingsQuery
+      .mockClear()
+      .mockReturnValue({
+        isLoading: false,
+        holdings: [{ id: 'holdingId', permanentLocationId: '001' }],
+      });
+  });
+
   it('should display holding locations', () => {
     renderLineLocationsView();
 

--- a/src/common/hooks/useReceive.js
+++ b/src/common/hooks/useReceive.js
@@ -26,6 +26,7 @@ export const useReceive = (options = {}) => {
           displayOnHolding: piece.displayOnHolding,
           enumeration: piece.enumeration,
           supplement: piece.supplement,
+          receivingTenantId: piece.receivingTenantId,
           locationId: piece.locationId || null,
           holdingId: piece.holdingId || null,
           createItem: piece.isCreateItem,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIREC-365

In ECS mode with the "Central ordering" setting activated, the user should be able to select an affiliation where the location/holding of the piece will be chosen.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

Use ACQ components designed to determine the state of the "Central Ordering" setting and load locations/holdings depending on the settings.

## Screenshots

https://github.com/folio-org/ui-receiving/assets/88109087/a27b6ebd-b520-441c-9808-33a217d9a642


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
