### PR TITLE
UIREC-377: Clear Item details when "Save and create another" option for adding electronic piece

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Receiving app closes after closing Routing list page. Refs UIREC-380.
 * Improve item record behavior for items associated with receiving pieces after binding. Refs UIREC-371.
 * Move the piece form out of the modal to a separate route with a full view. Refs UIREC-368.
+* Clear Item details when "Save and create another" option for adding electronic piece. Refs UIREC-377.
 
 ## [5.0.4](https://github.com/folio-org/ui-receiving/tree/v5.0.4) (2024-04-22)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v5.0.3...v5.0.4)

--- a/src/Piece/PieceForm/PieceForm.js
+++ b/src/Piece/PieceForm/PieceForm.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import {
   useCallback,
+  useEffect,
   useRef,
 } from 'react';
 import { FormattedMessage } from 'react-intl';
@@ -30,6 +31,7 @@ import {
   DeleteHoldingsModal,
   handleKeyCommand,
   HOLDINGS_API,
+  PIECE_FORMAT,
   PIECE_STATUS,
   useModalToggle,
 } from '@folio/stripes-acq-components';
@@ -96,6 +98,17 @@ const PieceForm = ({
     metadata,
     receivingStatus,
   } = formValues;
+
+  useEffect(() => {
+    if (!id && formValues?.format === PIECE_FORMAT.electronic) {
+      batch(() => {
+        change(PIECE_FORM_FIELD_NAMES.isCreateItem, false);
+        change(PIECE_FORM_FIELD_NAMES.barcode, undefined);
+        change(PIECE_FORM_FIELD_NAMES.callNumber, undefined);
+        change(PIECE_FORM_FIELD_NAMES.accessionNumber, undefined);
+      });
+    }
+  }, [batch, change, id, formValues]);
 
   const [isDeleteConfirmation, toggleDeleteConfirmation] = useModalToggle();
   const [isDeleteHoldingsConfirmation, toggleDeleteHoldingsConfirmation] = useModalToggle();

--- a/src/Piece/PieceForm/PieceForm.js
+++ b/src/Piece/PieceForm/PieceForm.js
@@ -89,6 +89,7 @@ const PieceForm = ({
   const {
     enumeration,
     externalNote,
+    format,
     id,
     internalNote,
     itemId,
@@ -100,7 +101,7 @@ const PieceForm = ({
   } = formValues;
 
   useEffect(() => {
-    if (!id && formValues?.format === PIECE_FORMAT.electronic) {
+    if (!id && format === PIECE_FORMAT.electronic) {
       batch(() => {
         change(PIECE_FORM_FIELD_NAMES.isCreateItem, false);
         change(PIECE_FORM_FIELD_NAMES.barcode, undefined);
@@ -108,7 +109,7 @@ const PieceForm = ({
         change(PIECE_FORM_FIELD_NAMES.accessionNumber, undefined);
       });
     }
-  }, [batch, change, id, formValues]);
+  }, [batch, change, format, id]);
 
   const [isDeleteConfirmation, toggleDeleteConfirmation] = useModalToggle();
   const [isDeleteHoldingsConfirmation, toggleDeleteHoldingsConfirmation] = useModalToggle();

--- a/src/Piece/PieceForm/PieceForm.test.js
+++ b/src/Piece/PieceForm/PieceForm.test.js
@@ -318,6 +318,31 @@ describe('PieceForm', () => {
     });
   });
 
+  it('should clear Item details inputs when change format from physical to electronic', async () => {
+    renderPieceForm({
+      pieceFormatOptions: [
+        { value: PIECE_FORMAT.physical, label: 'Physical' },
+        { value: PIECE_FORMAT.electronic, label: 'Electronic' },
+        { value: PIECE_FORMAT.other, label: 'Other' },
+      ],
+      initialValues: {
+        isCreateAnother: true,
+        receivingStatus: PIECE_STATUS.expected,
+        format: PIECE_FORMAT.physical,
+        barcode: 'barcode',
+        callNumber: 'callNumber',
+      },
+    });
+
+    const formatlabel = screen.getByText('ui-receiving.piece.format');
+
+    await user.click(formatlabel);
+    await user.selectOptions(screen.getByRole('combobox', { name: 'ui-receiving.piece.format' }), 'Electronic');
+
+    expect(screen.getByLabelText('ui-receiving.piece.barcode')).toHaveValue('');
+    expect(screen.getByLabelText('ui-receiving.piece.callNumber')).toHaveValue('');
+  });
+
   it('should update piece status', async () => {
     const onChange = jest.fn();
 


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
[UIREC-377](https://folio-org.atlassian.net/browse/UIREC-377): Clear Item details when "Save and create another" option for adding electronic piece
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

https://github.com/user-attachments/assets/0c172edb-63d3-4ab0-98c0-4a618ba5cd7a

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
