### PR TITLE
UIREC-361: ECS - "Select holdings" and "Affiliation" fields on "Edit piece" form for Unreceivable piece should be NOT editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * ECS - Disable Item Connected link when item is located in another tenant. Refs UIREC-387.
 * ECS - Optimize requests to fetch consortium items and holdings. Refs UIREC-389.
 * ECS - Fix the issue of creating new holdings instead of using existing ones in the bind form. Refs UIREC-391.
+* ECS - "Select holdings" and "Affiliation" fields on "Edit piece" form for Unreceivable piece should be NOT editable. Refs UIREC-361.
 
 ## [5.0.5](https://github.com/folio-org/ui-receiving/tree/v5.0.5) (2024-08-05)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v5.0.4...v5.0.5)

--- a/src/Piece/PieceForm/PieceFields/PieceFields.js
+++ b/src/Piece/PieceForm/PieceFields/PieceFields.js
@@ -42,6 +42,7 @@ export const PieceFields = ({
   const { values } = useFormState();
 
   const isNotReceived = values.receivingStatus !== PIECE_STATUS.received;
+  const isLocationSelectionDisabled = !isNotReceived || values.receivingStatus === PIECE_STATUS.unreceivable;
   const isLocationRequired = includes(createInventoryValues[values.format], INVENTORY_RECORDS_TYPE.instanceAndHolding);
   const isDisplayToPublic = values.displayOnHolding;
 
@@ -295,7 +296,8 @@ export const PieceFields = ({
             holdingName={PIECE_FORM_FIELD_NAMES.holdingId}
             locationName={PIECE_FORM_FIELD_NAMES.locationId}
             onChange={setLocationValue}
-            disabled={!isNotReceived}
+            disabled={isLocationSelectionDisabled}
+            isNonInteractive={isLocationSelectionDisabled}
             required={isLocationRequired}
           />
         </Col>

--- a/src/Piece/PieceForm/PieceForm.js
+++ b/src/Piece/PieceForm/PieceForm.js
@@ -118,8 +118,8 @@ const PieceForm = ({
   const isSaveAndCreateDisabled = disabled || protectUpdate || protectCreate;
   const isSaveAndCloseDisabled = disabled || (protectUpdate && Boolean(id));
   const isEditDisabled = disabled || protectUpdate;
-  const hasBoundItem = Boolean(bindItemId && isBound);
-  const itemDetailsAccordionLabelId = hasBoundItem
+  const isOriginalItemDetailsVisible = Boolean(itemId && bindItemId && isBound);
+  const itemDetailsAccordionLabelId = isOriginalItemDetailsVisible
     ? PIECE_MODAL_ACCORDION.originalItemDetails
     : PIECE_MODAL_ACCORDION.itemDetails;
 

--- a/src/Piece/PieceForm/PieceForm.test.js
+++ b/src/Piece/PieceForm/PieceForm.test.js
@@ -209,19 +209,22 @@ describe('PieceForm', () => {
 
     it('should display item details original when `Bound` has been checked and has `bindItemId`', async () => {
       renderPieceForm({
-        createInventoryValues: { [PIECE_FORMAT.physical]: INVENTORY_RECORDS_TYPE.instanceAndHolding },
+        createInventoryValues: {
+          [PIECE_FORMAT.physical]: INVENTORY_RECORDS_TYPE.instanceAndHolding,
+        },
         initialValues: {
           format: PIECE_FORMAT.physical,
           isBound: true,
           bindItemId: 'bindItemId',
           receivingStatus: PIECE_STATUS.received,
+          itemId: '1',
         },
       });
 
       const boundCheckbox = screen.getByLabelText('ui-receiving.piece.isBound');
 
       expect(boundCheckbox).toBeChecked();
-      expect(screen.getByText('ui-receiving.piece.accordion.originalItemDetails')).toBeDefined();
+      expect(screen.getByText('ui-receiving.piece.accordion.originalItemDetails')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
[UIREC-361](https://folio-org.atlassian.net/browse/UIREC-361): ECS - "Select holdings" and "Affiliation" fields on "Edit piece" form for Unreceivable piece should be NOT editable
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

https://github.com/user-attachments/assets/14df5f6e-b071-4ace-accd-a78a22916e78

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
