### PR TITLE
Update min inventory interface version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
       "identifier-types": "1.2",
       "instance-formats": "2.0",
       "instance-types": "2.0",
-      "inventory": "10.0 11.0 12.0 13.0 14.0",
+      "inventory": "10.0 11.0 12.0 13.2 14.0",
       "location-units": "2.0",
       "locations": "3.0",
       "material-types": "2.2",

--- a/src/TitleDetails/BoundItemsList/hooks/useBoundItems/useBoundItems.js
+++ b/src/TitleDetails/BoundItemsList/hooks/useBoundItems/useBoundItems.js
@@ -39,7 +39,7 @@ export const useBoundItems = ({ titleId, poLineId, options = {} }) => {
     enabled
     && titleId
     && poLineId
-    && stripes.hasInterface('inventory', '13.2'),
+    && stripes.hasInterface('inventory'),
   );
 
   const {

--- a/src/TitleDetails/TitleDetails.js
+++ b/src/TitleDetails/TitleDetails.js
@@ -34,7 +34,6 @@ import {
   Row,
 } from '@folio/stripes/components';
 import {
-  IfInterface,
   IfPermission,
   TitleManager,
   useStripes,

--- a/src/TitleDetails/TitleDetails.js
+++ b/src/TitleDetails/TitleDetails.js
@@ -574,22 +574,17 @@ const TitleDetails = ({
               )}
             </ColumnManager>
 
-            <IfInterface
-              name="inventory"
-              version="13.2"
+            <Accordion
+              id={TITLE_ACCORDION.boundItems}
+              label={TITLE_ACCORDION_LABELS.boundItems}
             >
-              <Accordion
-                id={TITLE_ACCORDION.boundItems}
-                label={TITLE_ACCORDION_LABELS.boundItems}
-              >
-                <BoundItemsList
-                  key={piecesExistence?.key}
-                  id="bound-items-list"
-                  filters={boundItemsFilters}
-                  title={title}
-                />
-              </Accordion>
-            </IfInterface>
+              <BoundItemsList
+                key={piecesExistence?.key}
+                id="bound-items-list"
+                filters={boundItemsFilters}
+                title={title}
+              />
+            </Accordion>
           </AccordionSet>
         </AccordionStatus>
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
`<IfInterface>` check interface version in the major version borders, so `version="13.2"` is equivalent to `^13.2`, not `>=13.2`. As an alternative we could use `version="13.2 14"`, but we have to remember about updating the version in this place. So it makes sense to specify minimal available version for `inventory` interface (in borders of 13) 

https://github.com/folio-org/stripes-core/blob/0e4d2b45f69612c1ffffd7bf47c06c3c14a8ded4/src/discoverServices.js#L325-L339

