### PR TITLE
UIREC-362 Hide 'Add piece' action when related order has 'Pending' status and 'Synchronized' workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 6.1.0 (IN PROGRESS)
 
+* Hide "Add piece" action when related order has "Pending" status and "Synchronized" workflow. Refs UIREC-362.
+
 ## [6.0.5](https://github.com/folio-org/ui-receiving/tree/v6.0.5) (2024-12-13)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v6.0.4...v6.0.5)
 

--- a/src/Piece/constants.js
+++ b/src/Piece/constants.js
@@ -206,3 +206,8 @@ export const PIECE_ACTION_NAMES = {
   expect: 'expect',
   delete: 'delete',
 };
+
+export const EXPECTED_PIECES_ACTION_NAMES = {
+  addPiece: 'addPiece',
+  receive: 'receive',
+};

--- a/src/TitleDetails/TitleDetails.js
+++ b/src/TitleDetails/TitleDetails.js
@@ -316,10 +316,10 @@ const TitleDetails = ({
 
   const expectedPiecesActions = useMemo(() => (
     <TitleDetailsExpectedActions
+      actionsHidden={expectedPiecesProtectedActions}
       applyFilters={applyExpectedPiecesFilters}
       filters={expectedPiecesFilters}
       hasReceive={hasReceive}
-      hiddenActions={expectedPiecesProtectedActions}
       openReceiveList={onReceivePieces}
       onPieceCreate={onPieceCreate}
       titleId={titleId}

--- a/src/TitleDetails/TitleDetailsActions/TitleDetailsExpectedActions.js
+++ b/src/TitleDetails/TitleDetailsActions/TitleDetailsExpectedActions.js
@@ -16,18 +16,19 @@ import {
 
 import {
   EXPECTED_PIECE_COLUMN_MAPPING,
+  EXPECTED_PIECES_ACTION_NAMES,
   MENU_FILTERS,
   SUPPLEMENT_MENU_FILTER_OPTIONS,
 } from '../../Piece';
 
 export function TitleDetailsExpectedActions({
   applyFilters,
+  disabledActions,
   filters,
+  hiddenActions,
   onPieceCreate,
   openReceiveList,
   hasReceive,
-  disabled,
-  canAddPiece,
   toggleColumn,
   visibleColumns,
 }) {
@@ -47,25 +48,27 @@ export function TitleDetailsExpectedActions({
           label={intl.formatMessage({ id: 'stripes-components.paneMenuActionsToggleLabel' })}
           id="expected-pieces-menu-actions"
         >
-          <Button
-            data-testid="add-piece-button"
-            data-test-add-piece-button
-            buttonStyle="dropdownItem"
-            onClick={onPieceCreate}
-            disabled={!canAddPiece}
-          >
-            <Icon size="small" icon="plus-sign">
-              <FormattedMessage id="ui-receiving.piece.button.addPiece" />
-            </Icon>
-          </Button>
+          {(!hiddenActions?.[EXPECTED_PIECES_ACTION_NAMES.addPiece]) && (
+            <Button
+              data-testid="add-piece-button"
+              data-test-add-piece-button
+              buttonStyle="dropdownItem"
+              onClick={onPieceCreate}
+              disabled={disabledActions?.[EXPECTED_PIECES_ACTION_NAMES.addPiece]}
+            >
+              <Icon size="small" icon="plus-sign">
+                <FormattedMessage id="ui-receiving.piece.button.addPiece" />
+              </Icon>
+            </Button>
+          )}
 
-          {hasReceive && (
+          {(!hiddenActions?.[EXPECTED_PIECES_ACTION_NAMES.receive]) && (
             <Button
               data-testid="receive-button"
               data-test-title-receive-button
               buttonStyle="dropdownItem"
               onClick={openReceiveList}
-              disabled={disabled}
+              disabled={disabledActions?.[EXPECTED_PIECES_ACTION_NAMES.receive]}
             >
               <Icon size="small" icon="receive">
                 <FormattedMessage id="ui-receiving.title.details.button.receive" />
@@ -98,12 +101,12 @@ export function TitleDetailsExpectedActions({
 
 TitleDetailsExpectedActions.propTypes = {
   applyFilters: PropTypes.func.isRequired,
+  disabledActions: PropTypes.object,
   filters: PropTypes.object.isRequired,
   hasReceive: PropTypes.bool.isRequired,
+  hiddenActions: PropTypes.object,
   onPieceCreate: PropTypes.func.isRequired,
   openReceiveList: PropTypes.func.isRequired,
   toggleColumn: PropTypes.func.isRequired,
   visibleColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
-  disabled: PropTypes.bool,
-  canAddPiece: PropTypes.bool,
 };

--- a/src/TitleDetails/TitleDetailsActions/TitleDetailsExpectedActions.js
+++ b/src/TitleDetails/TitleDetailsActions/TitleDetailsExpectedActions.js
@@ -22,10 +22,10 @@ import {
 } from '../../Piece';
 
 export function TitleDetailsExpectedActions({
+  actionsDisabled,
+  actionsHidden,
   applyFilters,
-  disabledActions,
   filters,
-  hiddenActions,
   onPieceCreate,
   openReceiveList,
   hasReceive,
@@ -48,13 +48,13 @@ export function TitleDetailsExpectedActions({
           label={intl.formatMessage({ id: 'stripes-components.paneMenuActionsToggleLabel' })}
           id="expected-pieces-menu-actions"
         >
-          {(!hiddenActions?.[EXPECTED_PIECES_ACTION_NAMES.addPiece]) && (
+          {(!actionsHidden?.[EXPECTED_PIECES_ACTION_NAMES.addPiece]) && (
             <Button
               data-testid="add-piece-button"
               data-test-add-piece-button
               buttonStyle="dropdownItem"
               onClick={onPieceCreate}
-              disabled={disabledActions?.[EXPECTED_PIECES_ACTION_NAMES.addPiece]}
+              disabled={actionsDisabled?.[EXPECTED_PIECES_ACTION_NAMES.addPiece]}
             >
               <Icon size="small" icon="plus-sign">
                 <FormattedMessage id="ui-receiving.piece.button.addPiece" />
@@ -62,13 +62,13 @@ export function TitleDetailsExpectedActions({
             </Button>
           )}
 
-          {(!hiddenActions?.[EXPECTED_PIECES_ACTION_NAMES.receive]) && (
+          {(!actionsHidden?.[EXPECTED_PIECES_ACTION_NAMES.receive]) && (
             <Button
               data-testid="receive-button"
               data-test-title-receive-button
               buttonStyle="dropdownItem"
               onClick={openReceiveList}
-              disabled={disabledActions?.[EXPECTED_PIECES_ACTION_NAMES.receive]}
+              disabled={actionsDisabled?.[EXPECTED_PIECES_ACTION_NAMES.receive]}
             >
               <Icon size="small" icon="receive">
                 <FormattedMessage id="ui-receiving.title.details.button.receive" />
@@ -100,11 +100,11 @@ export function TitleDetailsExpectedActions({
 }
 
 TitleDetailsExpectedActions.propTypes = {
+  actionsDisabled: PropTypes.object,
+  actionsHidden: PropTypes.object,
   applyFilters: PropTypes.func.isRequired,
-  disabledActions: PropTypes.object,
   filters: PropTypes.object.isRequired,
   hasReceive: PropTypes.bool.isRequired,
-  hiddenActions: PropTypes.object,
   onPieceCreate: PropTypes.func.isRequired,
   openReceiveList: PropTypes.func.isRequired,
   toggleColumn: PropTypes.func.isRequired,

--- a/src/TitleDetails/TitleDetailsActions/TitleDetailsExpectedActions.test.js
+++ b/src/TitleDetails/TitleDetailsActions/TitleDetailsExpectedActions.test.js
@@ -4,7 +4,10 @@ import {
 } from '@folio/jest-config-stripes/testing-library/react';
 import user from '@folio/jest-config-stripes/testing-library/user-event';
 
-import { EXPECTED_PIECE_VISIBLE_COLUMNS } from '../../Piece';
+import {
+  EXPECTED_PIECE_VISIBLE_COLUMNS,
+  EXPECTED_PIECES_ACTION_NAMES,
+} from '../../Piece';
 import { TitleDetailsExpectedActions } from './TitleDetailsExpectedActions';
 
 const defaultProps = {
@@ -57,7 +60,11 @@ describe('TitleDetailsExpectedActions', () => {
 
   it('should not call openReceiveList when receive button is pressed and actions are disabled', async () => {
     defaultProps.openReceiveList.mockClear();
-    renderTitleDetailsExpectedActions({ ...defaultProps, disabled: true });
+    renderTitleDetailsExpectedActions({
+      actionsDisabled: {
+        [EXPECTED_PIECES_ACTION_NAMES.receive]: true,
+      },
+    });
 
     await user.click(screen.getByTestId('expected-pieces-action-dropdown'));
     await user.click(screen.getByTestId('receive-button'));
@@ -65,14 +72,42 @@ describe('TitleDetailsExpectedActions', () => {
     expect(defaultProps.openReceiveList).not.toHaveBeenCalled();
   });
 
+  it('should not render "Receive" button when the action is hidden', async () => {
+    renderTitleDetailsExpectedActions({
+      actionsHidden: {
+        [EXPECTED_PIECES_ACTION_NAMES.receive]: true,
+      },
+    });
+
+    await user.click(screen.getByTestId('expected-pieces-action-dropdown'));
+
+    expect(screen.queryByTestId('receive-button')).not.toBeInTheDocument();
+  });
+
   it('should not call onPieceCreate when add piece button is pressed and actions are disabled', async () => {
     defaultProps.onPieceCreate.mockClear();
-    renderTitleDetailsExpectedActions({ ...defaultProps, disabled: true });
+    renderTitleDetailsExpectedActions({
+      actionsDisabled: {
+        [EXPECTED_PIECES_ACTION_NAMES.addPiece]: true,
+      },
+    });
 
     await user.click(screen.getByTestId('expected-pieces-action-dropdown'));
     await user.click(screen.getByTestId('add-piece-button'));
 
     expect(defaultProps.onPieceCreate).not.toHaveBeenCalled();
+  });
+
+  it('should not render "Add piece" button when the action is hidden', async () => {
+    renderTitleDetailsExpectedActions({
+      actionsHidden: {
+        [EXPECTED_PIECES_ACTION_NAMES.addPiece]: true,
+      },
+    });
+
+    await user.click(screen.getByTestId('expected-pieces-action-dropdown'));
+
+    expect(screen.queryByTestId('add-piece-button')).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIREC-362

## Approach

Declaratively hide and disable expected pieces' actions.

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/user-attachments/assets/b1bf090b-1b94-4144-8e5e-031569a4ddc7


<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->
- Hide vs Disable - https://ux.folio.org/docs/guidelines/ux-patterns/hiding-vs-disabling-elements-ux-pattern/
## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
