### PR TITLE
UIREC-493 Standardize scrollbar behavior of Receive table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 8.0.0 (IN PROGRESS)
 
-* Standardize scrollbar behavior of the Receive table. Refs UIREC-493.
 * *BREAKING* Update `orders` and `order-lines` interfaces to `13.0` and `4.0` accordingly. Refs UIREC-447.
 * Allow user to "Unlink" title from package POL view. Refs UIREC-448.
 * Hide "Remove from package" actions for titles related to non-package PO Lines. Refs UIREC-452.
@@ -34,6 +33,7 @@
 * Force unmounting of the location component on receiving page change. Refs UIREC-487.
 * Reuse shared utils to check holdings abandonment on piece form. Refs UIREC-491.
 * Fix locale-dependent date format in PieceForm tests. Refs UIREC-495.
+* Standardize scrollbar behavior of the Receive table. Refs UIREC-493.
 
 ## [7.0.2](https://github.com/folio-org/ui-receiving/tree/v7.0.2) (2025-04-14)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v7.0.1...v7.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 8.0.0 (IN PROGRESS)
 
+* Standardize scrollbar behavior of the Receive table. Refs UIREC-493.
 * *BREAKING* Update `orders` and `order-lines` interfaces to `13.0` and `4.0` accordingly. Refs UIREC-447.
 * Allow user to "Unlink" title from package POL view. Refs UIREC-448.
 * Hide "Remove from package" actions for titles related to non-package PO Lines. Refs UIREC-452.

--- a/src/TitleReceive/TitleReceive.css
+++ b/src/TitleReceive/TitleReceive.css
@@ -1,0 +1,10 @@
+.receiveListWrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.receiveListContent {
+  flex: 1;
+  min-height: 0;
+}

--- a/src/TitleReceive/TitleReceive.js
+++ b/src/TitleReceive/TitleReceive.js
@@ -20,6 +20,7 @@ import {
 import { LineLocationsView } from '../common/components';
 import { setLocationValueFormMutator } from '../common/utils';
 import { TitleReceiveList } from './TitleReceiveList';
+import css from './TitleReceive.css';
 
 const FIELD_NAME = 'receivedItems';
 
@@ -100,34 +101,38 @@ const TitleReceive = ({
             paneTitle={paneTitle}
             paneSub={paneSub}
           >
-            <LineLocationsView
-              crossTenant={crossTenant}
-              instanceId={instanceId}
-              poLine={poLine}
-              locations={locations}
-            />
-            {receivingNote && (
-              <Layout className="marginTopHalf">
-                <MessageBanner>
-                  {receivingNote}
-                </MessageBanner>
-              </Layout>
-            )}
-            <FieldArray
-              component={TitleReceiveList}
-              id="receivedItems"
-              name={FIELD_NAME}
-              props={{
-                createInventoryValues,
-                crossTenant,
-                instanceId,
-                isLoading,
-                locations,
-                poLineLocationIds,
-                selectLocation: form.mutators.setLocationValue,
-                toggleCheckedAll: form.mutators.toggleCheckedAll,
-              }}
-            />
+            <div className={css.receiveListWrapper}>
+              <LineLocationsView
+                crossTenant={crossTenant}
+                instanceId={instanceId}
+                poLine={poLine}
+                locations={locations}
+              />
+              {receivingNote && (
+                <Layout className="marginTopHalf">
+                  <MessageBanner>
+                    {receivingNote}
+                  </MessageBanner>
+                </Layout>
+              )}
+              <div className={css.receiveListContent}>
+                <FieldArray
+                  component={TitleReceiveList}
+                  id="receivedItems"
+                  name={FIELD_NAME}
+                  props={{
+                    createInventoryValues,
+                    crossTenant,
+                    instanceId,
+                    isLoading,
+                    locations,
+                    poLineLocationIds,
+                    selectLocation: form.mutators.setLocationValue,
+                    toggleCheckedAll: form.mutators.toggleCheckedAll,
+                  }}
+                />
+              </div>
+            </div>
           </Pane>
         </Paneset>
       </HasCommand>

--- a/src/TitleReceive/TitleReceiveList.js
+++ b/src/TitleReceive/TitleReceiveList.js
@@ -400,6 +400,7 @@ export const TitleReceiveList = ({ fields, props }) => {
     <>
       <MultiColumnList
         rowProps={rowProps}
+        autosize
         columnMapping={columnMapping}
         columnWidths={columnWidths}
         contentData={fields.value}

--- a/src/TitleReceive/TitleReceiveList.test.js
+++ b/src/TitleReceive/TitleReceiveList.test.js
@@ -11,6 +11,8 @@ import {
 } from '@folio/jest-config-stripes/testing-library/react';
 import user from '@folio/jest-config-stripes/testing-library/user-event';
 
+import { MultiColumnList } from '@folio/stripes/components';
+
 import { useNumberGeneratorOptions } from '../common/hooks';
 import {
   ACCESSION_NUMBER_SETTING,
@@ -20,11 +22,20 @@ import {
   GENERATOR_ON,
   GENERATOR_OFF,
 } from '../common/constants';
-import TitleReceiveList from './TitleReceiveList';
+import { TitleReceiveList } from './TitleReceiveList';
 
 jest.mock('../common/hooks', () => ({
   useNumberGeneratorOptions: jest.fn(),
 }));
+
+jest.mock('@folio/stripes/components', () => {
+  const actual = jest.requireActual('@folio/stripes/components');
+
+  return {
+    ...actual,
+    MultiColumnList: jest.fn(actual.MultiColumnList),
+  };
+});
 
 const defaultProps = {
   fields: {
@@ -50,6 +61,29 @@ const renderTitleReceiveList = (props = {}) => {
 };
 
 describe('Render TitleReceiveList', () => {
+  beforeEach(() => {
+    MultiColumnList.mockClear();
+  });
+
+  it('should render MultiColumnList with autosize prop', () => {
+    useNumberGeneratorOptions.mockReturnValue({
+      data: {
+        [BARCODE_SETTING]: GENERATOR_OFF,
+        [CALL_NUMBER_SETTING]: GENERATOR_OFF,
+        [ACCESSION_NUMBER_SETTING]: GENERATOR_OFF,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderTitleReceiveList();
+
+    expect(MultiColumnList).toHaveBeenCalledWith(
+      expect.objectContaining({ autosize: true }),
+      expect.anything(),
+    );
+  });
+
   it('should not show the number generator button if generator settings are off', async () => {
     useNumberGeneratorOptions.mockReturnValue({
       data: {


### PR DESCRIPTION
## Description

Fixes the horizontal scrollbar position in the "Receive" pane. Previously the scrollbar appeared directly below the table rows (at the very bottom of the page content), instead of being anchored above the Cancel/Receive footer buttons.

## Solution

Wraps the pane content in a flex column layout (`TitleReceive.css`) and adds the `autosize` prop to `MultiColumnList`.

Refs [UIREC-493](https://folio-org.atlassian.net/browse/UIREC-493)