### PR TITLE
UIREC-495 Fix locale-dependent date format in PieceForm tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 8.0.0 (IN PROGRESS)
 
-* Fix locale-dependent date format in PieceForm tests. Refs UIREC-495.
 * *BREAKING* Update `orders` and `order-lines` interfaces to `13.0` and `4.0` accordingly. Refs UIREC-447.
 * Allow user to "Unlink" title from package POL view. Refs UIREC-448.
 * Hide "Remove from package" actions for titles related to non-package PO Lines. Refs UIREC-452.
@@ -33,6 +32,7 @@
 * Use the `receivingTenantId` parameter to filter pieces in central ordering mode. UIREC-486.
 * Force unmounting of the location component on receiving page change. Refs UIREC-487.
 * Reuse shared utils to check holdings abandonment on piece form. Refs UIREC-491.
+* Fix locale-dependent date format in PieceForm tests. Refs UIREC-495.
 
 ## [7.0.2](https://github.com/folio-org/ui-receiving/tree/v7.0.2) (2025-04-14)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v7.0.1...v7.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 8.0.0 (IN PROGRESS)
 
+* Fix locale-dependent date format in PieceForm tests. Refs UIREC-495.
 * *BREAKING* Update `orders` and `order-lines` interfaces to `13.0` and `4.0` accordingly. Refs UIREC-447.
 * Allow user to "Unlink" title from package POL view. Refs UIREC-448.
 * Hide "Remove from package" actions for titles related to non-package PO Lines. Refs UIREC-452.

--- a/src/Piece/PieceForm/PieceForm.test.js
+++ b/src/Piece/PieceForm/PieceForm.test.js
@@ -92,7 +92,6 @@ const logs = [
   },
 ];
 
-const DATE_FORMAT = 'MM/DD/YYYY';
 const today = dayjs();
 
 const renderPieceForm = (props = {}) => renderWithRouter(
@@ -394,7 +393,10 @@ describe('PieceForm', () => {
 
       await userEvent.click(screen.getByTestId('dropdown-trigger-button'));
       await userEvent.click(screen.getByTestId('delay-claim-button'));
-      await userEvent.type(screen.getByRole('textbox', { name: /field.delayTo/ }), date.format(DATE_FORMAT));
+
+      const delayToInput = screen.getByRole('textbox', { name: /field.delayTo/ });
+
+      await userEvent.type(delayToInput, date.format(delayToInput.placeholder));
       await userEvent.click(await findButton('stripes-acq-components.FormFooter.save'));
 
       expect(defaultProps.onSubmit).toHaveBeenCalledWith(

--- a/src/Piece/PieceForm/PieceFormContainer.test.js
+++ b/src/Piece/PieceForm/PieceFormContainer.test.js
@@ -82,7 +82,6 @@ jest.mock('../hooks', () => ({
   usePieceStatusChangeLog: jest.fn(() => ({ data: [] })),
 }));
 
-const DATE_FORMAT = 'MM/DD/YYYY';
 const today = dayjs();
 
 const mutatePieceMock = jest.fn(() => Promise.resolve({ id: 'piece-id' }));
@@ -284,7 +283,9 @@ describe('PieceFormContainer', () => {
 
     expect(screen.getByText('ui-receiving.piece.sendClaim.withIntegration.message')).toBeInTheDocument();
 
-    await userEvent.type(screen.getByRole('textbox', { name: /sendClaim.field.claimExpiryDate/ }), today.add(3, 'days').format(DATE_FORMAT));
+    const claimExpiryInput1 = screen.getByRole('textbox', { name: /sendClaim.field.claimExpiryDate/ });
+
+    await userEvent.type(claimExpiryInput1, today.add(3, 'days').format(claimExpiryInput1.placeholder));
     await userEvent.click(await screen.findByRole('button', { name: 'stripes-acq-components.FormFooter.save' }));
 
     expect(sendClaims).toHaveBeenCalledWith({
@@ -305,7 +306,9 @@ describe('PieceFormContainer', () => {
 
     expect(screen.getByText('ui-receiving.piece.sendClaim.withoutIntegration.message')).toBeInTheDocument();
 
-    await userEvent.type(screen.getByRole('textbox', { name: /sendClaim.field.claimExpiryDate/ }), today.add(3, 'days').format(DATE_FORMAT));
+    const claimExpiryInput2 = screen.getByRole('textbox', { name: /sendClaim.field.claimExpiryDate/ });
+
+    await userEvent.type(claimExpiryInput2, today.add(3, 'days').format(claimExpiryInput2.placeholder));
     await userEvent.click(await screen.findByRole('button', { name: 'stripes-acq-components.FormFooter.save' }));
 
     expect(updatePiecesStatus).toHaveBeenCalledWith({


### PR DESCRIPTION
Refs [UIREC-495](https://folio-org.atlassian.net/browse/UIREC-495)

`PieceForm.test.js` and `PieceFormContainer.test.js` used a hardcoded
`MM/DD/YYYY` date format when typing into Datepicker fields. On non-US
systems the Datepicker expects a different format (e.g. `DD.MM.YYYY`),
so the typed value is not recognized as a valid date, form validation
fails silently, and the submit handler is never called — causing 3 tests
to fail locally.

Fix: read the Datepicker's `placeholder` attribute as the format string
instead of hardcoding it (same approach used in UICLAIM-26).

The tests pass on CI (US locale), so this only affects developers on
non-US systems.