### PR TITLE
UIREC-493 Standardize scrollbar behavior of Receive table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 8.1.0 (IN PROGRESS)
 
+* Standardize scrollbar behavior of the Receive table. Refs UIREC-493.
+
 ## [8.0.4](https://github.com/folio-org/ui-receiving/tree/v8.0.4) (2026-05-25)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v8.0.3...v8.0.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 8.1.0 (IN PROGRESS)
 
+* Standardize scrollbar behavior of the Receive table. Refs UIREC-493.
+
 ## [8.0.0](https://github.com/folio-org/ui-receiving/tree/v8.0.0) (2026-04-17)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v7.0.2...v8.0.0)
 

--- a/src/TitleReceive/TitleReceive.css
+++ b/src/TitleReceive/TitleReceive.css
@@ -1,0 +1,10 @@
+.receiveListWrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.receiveListContent {
+  flex: 1;
+  min-height: 0;
+}

--- a/src/TitleReceive/TitleReceive.js
+++ b/src/TitleReceive/TitleReceive.js
@@ -20,6 +20,7 @@ import {
 import { LineLocationsView } from '../common/components';
 import { setLocationValueFormMutator } from '../common/utils';
 import { TitleReceiveList } from './TitleReceiveList';
+import css from './TitleReceive.css';
 
 const FIELD_NAME = 'receivedItems';
 
@@ -100,34 +101,38 @@ const TitleReceive = ({
             paneTitle={paneTitle}
             paneSub={paneSub}
           >
-            <LineLocationsView
-              crossTenant={crossTenant}
-              instanceId={instanceId}
-              poLine={poLine}
-              locations={locations}
-            />
-            {receivingNote && (
-              <Layout className="marginTopHalf">
-                <MessageBanner>
-                  {receivingNote}
-                </MessageBanner>
-              </Layout>
-            )}
-            <FieldArray
-              component={TitleReceiveList}
-              id="receivedItems"
-              name={FIELD_NAME}
-              props={{
-                createInventoryValues,
-                crossTenant,
-                instanceId,
-                isLoading,
-                locations,
-                poLineLocationIds,
-                selectLocation: form.mutators.setLocationValue,
-                toggleCheckedAll: form.mutators.toggleCheckedAll,
-              }}
-            />
+            <div className={css.receiveListWrapper}>
+              <LineLocationsView
+                crossTenant={crossTenant}
+                instanceId={instanceId}
+                poLine={poLine}
+                locations={locations}
+              />
+              {receivingNote && (
+                <Layout className="marginTopHalf">
+                  <MessageBanner>
+                    {receivingNote}
+                  </MessageBanner>
+                </Layout>
+              )}
+              <div className={css.receiveListContent}>
+                <FieldArray
+                  component={TitleReceiveList}
+                  id="receivedItems"
+                  name={FIELD_NAME}
+                  props={{
+                    createInventoryValues,
+                    crossTenant,
+                    instanceId,
+                    isLoading,
+                    locations,
+                    poLineLocationIds,
+                    selectLocation: form.mutators.setLocationValue,
+                    toggleCheckedAll: form.mutators.toggleCheckedAll,
+                  }}
+                />
+              </div>
+            </div>
           </Pane>
         </Paneset>
       </HasCommand>

--- a/src/TitleReceive/TitleReceiveList.js
+++ b/src/TitleReceive/TitleReceiveList.js
@@ -400,6 +400,7 @@ export const TitleReceiveList = ({ fields, props }) => {
     <>
       <MultiColumnList
         rowProps={rowProps}
+        autosize
         columnMapping={columnMapping}
         columnWidths={columnWidths}
         contentData={fields.value}

--- a/src/TitleReceive/TitleReceiveList.js
+++ b/src/TitleReceive/TitleReceiveList.js
@@ -1,11 +1,14 @@
 import includes from 'lodash/includes';
+import isEqual from 'lodash/isEqual';
 import noop from 'lodash/noop';
+import pick from 'lodash/pick';
 import PropTypes from 'prop-types';
 import {
   memo,
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import {
@@ -75,6 +78,24 @@ const visibleColumns = [
   PIECE_COLUMNS.isCreateItem,
   PIECE_COLUMNS.displayOnHolding,
   PIECE_COLUMNS.supplement,
+];
+
+// Only the fields actually consumed by cell formatters or CreateItemField.
+// Form-bound values (displaySummary, enumeration, comment, etc.) are resolved
+// via <Field name> and must be excluded so MCL's dataChangedOrLess() does not
+// treat every keystroke as content change and reset scrollTop to 0.
+const CONTENT_DATA_FIELDS = [
+  'id',
+  'bindItemId',
+  'format',
+  'holdingsRecordId',
+  'isBound',
+  'isCreateItem',
+  'itemId',
+  'itemStatus',
+  'receivingStatus',
+  'receivingTenantId',
+  'request',
 ];
 
 const accessionNumberFieldName = (field, index) => `${field}[${index}].accessionNumber`;
@@ -378,6 +399,18 @@ export const TitleReceiveList = ({ fields, props }) => {
     onKeyDown: onFieldKeyDown,
   }), [onFieldKeyDown]);
 
+  const contentDataRef = useRef();
+  const stableContentData = useMemo(() => {
+    const next = fields.value.map(item => pick(item, CONTENT_DATA_FIELDS));
+
+    if (contentDataRef.current && isEqual(contentDataRef.current, next)) {
+      return contentDataRef.current;
+    }
+    contentDataRef.current = next;
+
+    return next;
+  }, [fields.value]);
+
   const visibleColumnsWithActions = useMemo(() => {
     const vcwa = [...visibleColumns];
 
@@ -403,12 +436,12 @@ export const TitleReceiveList = ({ fields, props }) => {
         autosize
         columnMapping={columnMapping}
         columnWidths={columnWidths}
-        contentData={fields.value}
+        contentData={stableContentData}
         formatter={cellFormatters}
         id="title-receive-list"
         interactive={false}
         loading={isLoading}
-        totalCount={fields.value.length}
+        totalCount={stableContentData.length}
         visibleColumns={visibleColumnsWithActions}
       />
       <NumberGeneratorModal

--- a/src/TitleReceive/TitleReceiveList.test.js
+++ b/src/TitleReceive/TitleReceiveList.test.js
@@ -52,30 +52,20 @@ const defaultProps = {
 };
 
 const queryClient = new QueryClient();
-const renderTitleReceiveList = (props = {}) => {
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <Form onSubmit={() => {}} render={() => <TitleReceiveList {...defaultProps} {...props} />} />
-    </QueryClientProvider>,
-  );
-};
+const buildTitleReceiveList = (props = {}) => (
+  <QueryClientProvider client={queryClient}>
+    <Form onSubmit={() => {}} render={() => <TitleReceiveList {...defaultProps} {...props} />} />
+  </QueryClientProvider>
+);
+const renderTitleReceiveList = (props = {}) => render(buildTitleReceiveList(props));
 
 describe('Render TitleReceiveList', () => {
   beforeEach(() => {
     MultiColumnList.mockClear();
+    useNumberGeneratorOptions.mockReturnValue({ data: {} });
   });
 
   it('should render MultiColumnList with autosize prop', () => {
-    useNumberGeneratorOptions.mockReturnValue({
-      data: {
-        [BARCODE_SETTING]: GENERATOR_OFF,
-        [CALL_NUMBER_SETTING]: GENERATOR_OFF,
-        [ACCESSION_NUMBER_SETTING]: GENERATOR_OFF,
-      },
-      isLoading: false,
-      error: null,
-    });
-
     renderTitleReceiveList();
 
     expect(MultiColumnList).toHaveBeenCalledWith(
@@ -121,36 +111,14 @@ describe('Render TitleReceiveList', () => {
   });
 
   it('should keep contentData reference stable when only form-bound fields change', () => {
-    useNumberGeneratorOptions.mockReturnValue({
-      data: {
-        [BARCODE_SETTING]: GENERATOR_OFF,
-        [CALL_NUMBER_SETTING]: GENERATOR_OFF,
-        [ACCESSION_NUMBER_SETTING]: GENERATOR_OFF,
-      },
-      isLoading: false,
-      error: null,
-    });
-
     const baseRecord = { id: 'a', itemId: 'i', format: 'P', isCreateItem: false };
-    const renderWith = (value) => (
-      <QueryClientProvider client={queryClient}>
-        <Form
-          onSubmit={() => {}}
-          render={() => (
-            <TitleReceiveList
-              fields={{ value: [value], name: 'receivedItems' }}
-              props={defaultProps.props}
-            />
-          )}
-        />
-      </QueryClientProvider>
-    );
+    const fieldsWith = (value) => ({ fields: { value: [value], name: 'receivedItems' } });
 
-    const { rerender } = render(renderWith({ ...baseRecord, displaySummary: 'old' }));
+    const { rerender } = render(buildTitleReceiveList(fieldsWith({ ...baseRecord, displaySummary: 'old' })));
     const firstContentData = MultiColumnList.mock.calls[0][0].contentData;
 
     MultiColumnList.mockClear();
-    rerender(renderWith({ ...baseRecord, displaySummary: 'new' }));
+    rerender(buildTitleReceiveList(fieldsWith({ ...baseRecord, displaySummary: 'new' })));
 
     const secondContentData = MultiColumnList.mock.calls[0][0].contentData;
 
@@ -158,36 +126,14 @@ describe('Render TitleReceiveList', () => {
   });
 
   it('should rebuild contentData reference when a record field changes', () => {
-    useNumberGeneratorOptions.mockReturnValue({
-      data: {
-        [BARCODE_SETTING]: GENERATOR_OFF,
-        [CALL_NUMBER_SETTING]: GENERATOR_OFF,
-        [ACCESSION_NUMBER_SETTING]: GENERATOR_OFF,
-      },
-      isLoading: false,
-      error: null,
-    });
-
     const baseRecord = { id: 'a', itemId: 'i', isCreateItem: false, displaySummary: 'x' };
-    const renderWith = (value) => (
-      <QueryClientProvider client={queryClient}>
-        <Form
-          onSubmit={() => {}}
-          render={() => (
-            <TitleReceiveList
-              fields={{ value: [value], name: 'receivedItems' }}
-              props={defaultProps.props}
-            />
-          )}
-        />
-      </QueryClientProvider>
-    );
+    const fieldsWith = (value) => ({ fields: { value: [value], name: 'receivedItems' } });
 
-    const { rerender } = render(renderWith({ ...baseRecord, format: 'Physical' }));
+    const { rerender } = render(buildTitleReceiveList(fieldsWith({ ...baseRecord, format: 'Physical' })));
     const firstContentData = MultiColumnList.mock.calls[0][0].contentData;
 
     MultiColumnList.mockClear();
-    rerender(renderWith({ ...baseRecord, format: 'Electronic' }));
+    rerender(buildTitleReceiveList(fieldsWith({ ...baseRecord, format: 'Electronic' })));
 
     const secondContentData = MultiColumnList.mock.calls[0][0].contentData;
 

--- a/src/TitleReceive/TitleReceiveList.test.js
+++ b/src/TitleReceive/TitleReceiveList.test.js
@@ -120,6 +120,80 @@ describe('Render TitleReceiveList', () => {
     expect(button).toBeEnabled();
   });
 
+  it('should keep contentData reference stable when only form-bound fields change', () => {
+    useNumberGeneratorOptions.mockReturnValue({
+      data: {
+        [BARCODE_SETTING]: GENERATOR_OFF,
+        [CALL_NUMBER_SETTING]: GENERATOR_OFF,
+        [ACCESSION_NUMBER_SETTING]: GENERATOR_OFF,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const baseRecord = { id: 'a', itemId: 'i', format: 'P', isCreateItem: false };
+    const renderWith = (value) => (
+      <QueryClientProvider client={queryClient}>
+        <Form
+          onSubmit={() => {}}
+          render={() => (
+            <TitleReceiveList
+              fields={{ value: [value], name: 'receivedItems' }}
+              props={defaultProps.props}
+            />
+          )}
+        />
+      </QueryClientProvider>
+    );
+
+    const { rerender } = render(renderWith({ ...baseRecord, displaySummary: 'old' }));
+    const firstContentData = MultiColumnList.mock.calls[0][0].contentData;
+
+    MultiColumnList.mockClear();
+    rerender(renderWith({ ...baseRecord, displaySummary: 'new' }));
+
+    const secondContentData = MultiColumnList.mock.calls[0][0].contentData;
+
+    expect(secondContentData).toBe(firstContentData);
+  });
+
+  it('should rebuild contentData reference when a record field changes', () => {
+    useNumberGeneratorOptions.mockReturnValue({
+      data: {
+        [BARCODE_SETTING]: GENERATOR_OFF,
+        [CALL_NUMBER_SETTING]: GENERATOR_OFF,
+        [ACCESSION_NUMBER_SETTING]: GENERATOR_OFF,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const baseRecord = { id: 'a', itemId: 'i', isCreateItem: false, displaySummary: 'x' };
+    const renderWith = (value) => (
+      <QueryClientProvider client={queryClient}>
+        <Form
+          onSubmit={() => {}}
+          render={() => (
+            <TitleReceiveList
+              fields={{ value: [value], name: 'receivedItems' }}
+              props={defaultProps.props}
+            />
+          )}
+        />
+      </QueryClientProvider>
+    );
+
+    const { rerender } = render(renderWith({ ...baseRecord, format: 'Physical' }));
+    const firstContentData = MultiColumnList.mock.calls[0][0].contentData;
+
+    MultiColumnList.mockClear();
+    rerender(renderWith({ ...baseRecord, format: 'Electronic' }));
+
+    const secondContentData = MultiColumnList.mock.calls[0][0].contentData;
+
+    expect(secondContentData).not.toBe(firstContentData);
+  });
+
   it('should show the number generator modal when a number generator is enabled', async () => {
     const setNumberGeneratorModalRecordMock = jest.fn();
 

--- a/src/TitleReceive/TitleReceiveList.test.js
+++ b/src/TitleReceive/TitleReceiveList.test.js
@@ -11,6 +11,8 @@ import {
 } from '@folio/jest-config-stripes/testing-library/react';
 import user from '@folio/jest-config-stripes/testing-library/user-event';
 
+import { MultiColumnList } from '@folio/stripes/components';
+
 import { useNumberGeneratorOptions } from '../common/hooks';
 import {
   ACCESSION_NUMBER_SETTING,
@@ -20,11 +22,20 @@ import {
   GENERATOR_ON,
   GENERATOR_OFF,
 } from '../common/constants';
-import TitleReceiveList from './TitleReceiveList';
+import { TitleReceiveList } from './TitleReceiveList';
 
 jest.mock('../common/hooks', () => ({
   useNumberGeneratorOptions: jest.fn(),
 }));
+
+jest.mock('@folio/stripes/components', () => {
+  const actual = jest.requireActual('@folio/stripes/components');
+
+  return {
+    ...actual,
+    MultiColumnList: jest.fn(actual.MultiColumnList),
+  };
+});
 
 const defaultProps = {
   fields: {
@@ -50,6 +61,29 @@ const renderTitleReceiveList = (props = {}) => {
 };
 
 describe('Render TitleReceiveList', () => {
+  beforeEach(() => {
+    MultiColumnList.mockClear();
+  });
+
+  it('should render MultiColumnList with autosize prop', () => {
+    useNumberGeneratorOptions.mockReturnValue({
+      data: {
+        [BARCODE_SETTING]: GENERATOR_OFF,
+        [CALL_NUMBER_SETTING]: GENERATOR_OFF,
+        [ACCESSION_NUMBER_SETTING]: GENERATOR_OFF,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderTitleReceiveList();
+
+    expect(MultiColumnList).toHaveBeenCalledWith(
+      expect.objectContaining({ autosize: true }),
+      expect.anything(),
+    );
+  });
+
   it('should not show the number generator button if generator settings are off', async () => {
     useNumberGeneratorOptions.mockReturnValue({
       data: {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
- Wraps the Receive pane content in a flex column layout so the MCL scrollbar sits directly above the Cancel/Receive buttons instead of below the last row.                                                                       
- Adds `autosize` to `MultiColumnList` for proper scroll-area calculation.                                                                                                                                                        
- Preserves the scroll position when the user edits a form field inside a row (previously MCL reset `scrollTop` to 0 on every keystroke).

## Context      
Unlike `ui-users` or `ui-inventory`, the Receive table is not a search result set: it's a form rendered as a table. `SearchAndSortQuery` / `ResultsPane` are built for read-only result sets coming from a query, whereas here the user edits existing pieces inline. Each row is a `FieldArray` entry with form inputs (location picker, displaySummary, etc.), wrapped in a plain `<Pane>`, so `ResultsPane autosize` (which would pin the scrollbar for us) is  not available. The flex wrapper + `autosize` on the MCL is the manual equivalent of what `ResultsPane` does automatically.

The scroll-preservation fix is needed because `MCLRenderer` treats every non-trivial `contentData` change as `CHANGE_DIFFERENCE` / `CHANGE_LESSDATA` and resets `scrollTop = 0` (reasonable for sort/filter). With a `FieldArray`,
every keystroke produces a new array reference, so the table jumped to the top on every character. The fix builds a stable `contentData` projection that contains only record-level fields (`id`, `itemId`, `format`, …); form-bound fields reach MCL via `<Field name>` and no longer re-classify the content.

Re-submission of #714 which was reverted (#716) due to missing review approval. Sorry about that.

Refs [UIREC-493](https://folio-org.atlassian.net/browse/UIREC-493)   