### PR TITLE
UIREC-497 Display the quick receive confirmation for "Closed order" before a piece mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 8.1.0 (IN PROGRESS)
 
+* Display the quick receive confirmation for "Closed order" before a piece mutation. Refs UIREC-497.
+
 ## [8.0.0](https://github.com/folio-org/ui-receiving/tree/v8.0.0) (2026-04-17)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v7.0.2...v8.0.0)
 

--- a/src/Piece/PieceForm/PieceForm.js
+++ b/src/Piece/PieceForm/PieceForm.js
@@ -1,3 +1,4 @@
+import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 import {
   useCallback,
@@ -29,12 +30,15 @@ import {
   DeleteHoldingsModal,
   getClaimingIntervalFromDate,
   handleKeyCommand,
+  ORDER_STATUSES,
   PIECE_FORMAT,
   PIECE_STATUS,
   useModalToggle,
 } from '@folio/stripes-acq-components';
 
+import { ConfirmReceivingModal } from '../../common/components';
 import { PIECE_FORM_FIELD_NAMES } from '../../common/constants';
+import { useAsyncConfirmationModal } from '../../common/hooks';
 import { setLocationValueFormMutator } from '../../common/utils';
 import {
   PIECE_ACTION_NAMES,
@@ -63,6 +67,7 @@ const PieceForm = ({
   locationIds,
   locations,
   nextSequenceNumber,
+  order,
   paneTitle,
   pieceFormatOptions,
   poLine,
@@ -107,6 +112,13 @@ const PieceForm = ({
   const [isDeleteConfirmation, toggleDeleteConfirmation] = useModalToggle();
   const [isDeleteHoldingsConfirmation, toggleDeleteHoldingsConfirmation] = useModalToggle();
   const [isClaimDelayModalOpen, toggleClaimDelayModal] = useModalToggle();
+
+  const {
+    cancel: onCancelReceive,
+    confirm: onConfirmReceive,
+    init: initConfirmReceive,
+    isModalOpen: isConfirmReceiving,
+  } = useAsyncConfirmationModal();
 
   const { protectCreate, protectUpdate, protectDelete } = restrictionsByAcqUnit;
   const isEditMode = Boolean(id);
@@ -168,10 +180,21 @@ const PieceForm = ({
     onSave();
   }, [change, onSave]);
 
-  const onQuickReceive = useCallback(() => {
-    change(PIECE_FORM_SERVICE_FIELD_NAMES.postSubmitAction, PIECE_ACTION_NAMES.quickReceive);
-    onSave();
-  }, [change, onSave]);
+  const onQuickReceive = useCallback(async () => {
+    const handleQuickReceive = () => {
+      change(PIECE_FORM_SERVICE_FIELD_NAMES.postSubmitAction, PIECE_ACTION_NAMES.quickReceive);
+      onSave();
+    };
+
+    // Show confirmation modal if order is closed, otherwise receive piece immediately
+    if (order.workflowStatus === ORDER_STATUSES.closed) {
+      await initConfirmReceive()
+        .then(handleQuickReceive)
+        .catch(noop);
+    } else {
+      handleQuickReceive();
+    }
+  }, [change, initConfirmReceive, onSave, order.workflowStatus]);
 
   const onUnreceive = useCallback(() => {
     change(PIECE_FORM_SERVICE_FIELD_NAMES.postSubmitAction, PIECE_ACTION_NAMES.unReceive);
@@ -377,6 +400,12 @@ const PieceForm = ({
             onCancel={toggleClaimDelayModal}
             onSubmit={onClaimDelay}
           />
+
+          <ConfirmReceivingModal
+            open={isConfirmReceiving}
+            onCancel={onCancelReceive}
+            onConfirm={onConfirmReceive}
+          />
         </Pane>
       </Paneset>
     </HasCommand>
@@ -395,6 +424,9 @@ PieceForm.propTypes = {
   locationIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   locations: PropTypes.arrayOf(PropTypes.object),
   nextSequenceNumber: PropTypes.number,
+  order: PropTypes.shape({
+    workflowStatus: PropTypes.string,
+  }).isRequired,
   onClaimSend: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,

--- a/src/Piece/PieceForm/PieceForm.test.js
+++ b/src/Piece/PieceForm/PieceForm.test.js
@@ -8,6 +8,7 @@ import { dayjs } from '@folio/stripes/components';
 import {
   FieldInventory,
   INVENTORY_RECORDS_TYPE,
+  ORDER_STATUSES,
   PIECE_FORMAT,
   PIECE_STATUS,
   useCurrentUserTenants,
@@ -45,6 +46,9 @@ const defaultProps = {
   onClose: jest.fn(),
   onDelete: jest.fn(),
   onSubmit: jest.fn(),
+  order: {
+    workflowStatus: ORDER_STATUSES.open,
+  },
   initialValues: {
     isCreateAnother: false,
     [PIECE_FORM_FIELD_NAMES.sequenceNumber]: 42,
@@ -354,6 +358,57 @@ describe('PieceForm', () => {
 
   describe('Actions', () => {
     const date = today.add(3, 'days');
+
+    describe('Quick receive', () => {
+      it('should handle quick receive action for piece connected to open order', async () => {
+        renderPieceForm({
+          order: { workflowStatus: ORDER_STATUSES.open },
+          initialValues: {
+            ...defaultProps.initialValues,
+            receivingStatus: PIECE_STATUS.expected,
+            format: PIECE_FORMAT.physical,
+          },
+        });
+
+        await act(async () => userEvent.click(await screen.findByTestId('quickReceive')));
+
+        expect(screen.queryByText(/piece.confirmReceiving.title/)).not.toBeInTheDocument();
+        expect(defaultProps.onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({ postSubmitAction: PIECE_ACTION_NAMES.quickReceive }),
+          expect.anything(),
+          expect.anything(),
+        );
+      });
+
+      it('should handle quick receive action for piece connected to closed order', async () => {
+        renderPieceForm({
+          order: { workflowStatus: ORDER_STATUSES.closed },
+          initialValues: {
+            ...defaultProps.initialValues,
+            receivingStatus: PIECE_STATUS.expected,
+            format: PIECE_FORMAT.physical,
+          },
+        });
+
+        await act(async () => userEvent.click(await screen.findByTestId('quickReceive')));
+
+        // Confirmation modal should be shown for closed order
+        expect(screen.getByText(/piece.confirmReceiving.title/)).toBeInTheDocument();
+
+        await act(async () => userEvent.click(await findButton(/stripes-components.cancel/)));
+
+        expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+
+        await act(async () => userEvent.click(await screen.findByTestId('quickReceive')));
+        await act(async () => userEvent.click(await findButton(/piece.actions.confirm/)));
+
+        expect(defaultProps.onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({ postSubmitAction: PIECE_ACTION_NAMES.quickReceive }),
+          expect.anything(),
+          expect.anything(),
+        );
+      });
+    });
 
     it('should handle "Unreceive" action', async () => {
       renderPieceForm({

--- a/src/Piece/PieceForm/PieceFormContainer.js
+++ b/src/Piece/PieceForm/PieceFormContainer.js
@@ -25,7 +25,6 @@ import {
   useShowCallout,
 } from '@folio/stripes-acq-components';
 
-import { ConfirmReceivingModal } from '../../common/components';
 import { PIECE_FORM_FIELD_NAMES } from '../../common/constants';
 import {
   useOrder,
@@ -126,15 +125,7 @@ export const PieceFormContainer = ({
   const { mutatePiece } = usePieceMutator({ tenantId });
   const { unreceive } = useUnreceive({ tenantId });
 
-  const {
-    isConfirmReceiving,
-    onCancelReceive,
-    onConfirmReceive,
-    onQuickReceive,
-  } = usePieceQuickReceiving({
-    order,
-    tenantId,
-  });
+  const { onQuickReceive } = usePieceQuickReceiving({ tenantId });
 
   const {
     claimSendModalProps,
@@ -388,6 +379,7 @@ export const PieceFormContainer = ({
         onClose={onCloseForm}
         onDelete={onDelete}
         onSubmit={onSubmit}
+        order={order}
         locationIds={locationIds}
         locations={locations}
         nextSequenceNumber={title?.nextSequenceNumber}
@@ -395,12 +387,6 @@ export const PieceFormContainer = ({
         pieceFormatOptions={pieceFormatOptions}
         poLine={orderLine}
         restrictionsByAcqUnit={restrictions}
-      />
-
-      <ConfirmReceivingModal
-        open={isConfirmReceiving}
-        onCancel={onCancelReceive}
-        onConfirm={onConfirmReceive}
       />
 
       <SendClaimsModal

--- a/src/Piece/hooks/usePieceQuickReceiving/usePieceQuickReceiving.js
+++ b/src/Piece/hooks/usePieceQuickReceiving/usePieceQuickReceiving.js
@@ -1,14 +1,6 @@
-import noop from 'lodash/noop';
-import {
-  useCallback,
-  useRef,
-} from 'react';
+import { useCallback } from 'react';
 
-import {
-  ORDER_STATUSES,
-  useModalToggle,
-  useShowCallout,
-} from '@folio/stripes-acq-components';
+import { useShowCallout } from '@folio/stripes-acq-components';
 import { useOkapiKy } from '@folio/stripes/core';
 
 import { useReceive } from '../../../common/hooks';
@@ -21,18 +13,14 @@ import {
   handleReceiveErrorResponse,
 } from '../../../common/utils';
 
-export const usePieceQuickReceiving = ({
-  order,
-  tenantId,
-}) => {
+export const usePieceQuickReceiving = ({ tenantId } = {}) => {
   const ky = useOkapiKy({ tenant: tenantId });
   const showCallout = useShowCallout();
-  const [isConfirmReceiving, toggleConfirmReceiving] = useModalToggle();
 
-  const confirmReceivingPromise = useRef(Promise);
-  const isOrderClosed = order?.workflowStatus === ORDER_STATUSES.closed;
-
-  const { receive } = useReceive({ tenantId });
+  const {
+    isLoading,
+    receive,
+  } = useReceive({ tenantId });
 
   const quickReceive = useCallback(async (pieceValues) => {
     const { id } = pieceValues;
@@ -52,8 +40,8 @@ export const usePieceQuickReceiving = ({
     return receive({ pieces: [{ ...piece, ...itemData }] });
   }, [ky, receive, tenantId]);
 
-  const handleQuickReceive = useCallback((values, mutationFn) => {
-    return quickReceive(values, mutationFn)
+  const onQuickReceive = useCallback((values) => {
+    return quickReceive(values)
       .then((res) => {
         if (!values.id) {
           showCallout({
@@ -75,34 +63,8 @@ export const usePieceQuickReceiving = ({
       });
   }, [quickReceive, showCallout]);
 
-  const confirmReceiving = useCallback(
-    () => new Promise((resolve, reject) => {
-      confirmReceivingPromise.current = { resolve, reject };
-      toggleConfirmReceiving();
-    }),
-    [toggleConfirmReceiving],
-  );
-
-  const onQuickReceive = useCallback((values) => {
-    return isOrderClosed
-      ? confirmReceiving().then(() => handleQuickReceive(values), noop)
-      : handleQuickReceive(values);
-  }, [confirmReceiving, handleQuickReceive, isOrderClosed]);
-
-  const onConfirmReceive = () => {
-    confirmReceivingPromise.current.resolve();
-    toggleConfirmReceiving();
-  };
-
-  const onCancelReceive = () => {
-    confirmReceivingPromise.current.reject();
-    toggleConfirmReceiving();
-  };
-
   return {
-    isConfirmReceiving,
+    isLoading,
     onQuickReceive,
-    onCancelReceive,
-    onConfirmReceive,
   };
 };

--- a/src/Piece/hooks/usePieceQuickReceiving/usePieceQuickReceiving.test.js
+++ b/src/Piece/hooks/usePieceQuickReceiving/usePieceQuickReceiving.test.js
@@ -1,9 +1,6 @@
 import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
 
-import {
-  ITEM_STATUS,
-  ORDER_STATUSES,
-} from '@folio/stripes-acq-components';
+import { ITEM_STATUS } from '@folio/stripes-acq-components';
 
 import { useReceive } from '../../../common/hooks';
 import {
@@ -29,11 +26,6 @@ const pieceValues = {
   displaySummary: 'v1',
 };
 
-const order = {
-  id: 'po-id',
-  workflowStatus: ORDER_STATUSES.pending,
-};
-
 describe('usePieceQuickReceiving', () => {
   let receivePieceMock;
 
@@ -47,7 +39,7 @@ describe('usePieceQuickReceiving', () => {
   });
 
   it('should call receive', async () => {
-    const { result } = renderHook(() => usePieceQuickReceiving({ order }));
+    const { result } = renderHook(() => usePieceQuickReceiving({ tenantId: 'tenantId' }));
 
     await result.current.onQuickReceive(pieceValues);
 
@@ -60,7 +52,7 @@ describe('usePieceQuickReceiving', () => {
 
     beforeEach(() => {
       getPieceById.mockReturnValue(() => Promise.resolve({ json: () => ({ ...pieceValues, itemId }) }));
-      const { result } = renderHook(() => usePieceQuickReceiving({ order }));
+      const { result } = renderHook(() => usePieceQuickReceiving());
 
       quickReceive = result.current.onQuickReceive;
     });


### PR DESCRIPTION
## Purpose

When receiving a piece from a closed order through the quick-receive action, the system should confirm this action with the user first, since receiving pieces on closed orders is an exceptional case.

**Problem identified**: The previous implementation had a critical issue where the `ConfirmReceivingModal` was rendered in `PieceFormContainer`. During the piece mutation, `isLoadingState` becomes `true`, causing the container to display `<LoadingView />` instead of its child components. This prevented the confirmation modal from being rendered, effectively freezing the UI:

- User clicks "quick receive" on a piece from a closed order
- The form submission triggers `isLoadingState = true`
- `PieceFormContainer` renders `<LoadingView />` instead of the form and modal
- The confirmation modal never appears, blocking the user
- The application hangs waiting for user confirmation that never comes

Reference: https://folio-org.atlassian.net/browse/UIREC-497

## Approach

The implementation moves the quick-receive confirmation logic into the `PieceForm` component, ensuring the modal is always rendered and interactive regardless of the container's loading state:

1. **Decoupled Modal Rendering**: Moved `ConfirmReceivingModal` from `PieceFormContainer` into `PieceForm` component, so it renders inside the form and stays visible before mutations
2. **Order Status Check**: Added `order` prop to `PieceForm` to detect when the connected order is closed
3. **Async Modal Flow**: Uses `useAsyncConfirmationModal` hook directly in the form for promise-based confirmation handling
4. **Conditional Confirmation**: 
   - For **open orders**: Quick receive proceeds immediately (backward compatible)
   - For **closed orders**: Shows `ConfirmReceivingModal` for user confirmation before mutation
5. **Simplified Hook**: Cleaned up `usePieceQuickReceiving` to remove modal state management—it now only handles receiving logic
6. **Test Coverage**: Added comprehensive tests for both open and closed order scenarios

## Key Benefits

✅ Modal is always accessible and interactive to the user  
✅ Loading state no longer blocks confirmation UI  
✅ Clear separation: component handles UX flow, hook handles business logic  
✅ Backward compatible with existing quick-receive behavior for open orders

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/user-attachments/assets/5df0a9df-a3f7-48a9-8cfe-4da0d625fc51

