### PR TITLE
UIREC-494 Add column manager to Receiving list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 8.1.0 (IN PROGRESS)
 
+* Add column manager to the Receiving results list. Refs UIREC-494.
 * Standardize scrollbar behavior of the Receive table. Refs UIREC-493.
 
 ## [8.0.4](https://github.com/folio-org/ui-receiving/tree/v8.0.4) (2026-05-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## 9.0.0 (IN PROGRESS)
 
-* *BREAKING* Update CQL queries to use the new indices. Refs UIREC-504.
-
 * Add column manager to the Receiving results list. Refs UIREC-494.
 * Standardize scrollbar behavior of the Receive table. Refs UIREC-493.
+* *BREAKING* Update CQL queries to use the new indices. Refs UIREC-504.
 * Add notice when searching sequences in number generators modal without permissions. Refs SI-166.
 
 ## [8.0.4](https://github.com/folio-org/ui-receiving/tree/v8.0.4) (2026-05-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 8.1.0 (IN PROGRESS)
 
 * Display the quick receive confirmation for "Closed order" before a piece mutation. Refs UIREC-497.
+* Add column manager to the Receiving results list. Refs UIREC-494.
 
 ## [8.0.0](https://github.com/folio-org/ui-receiving/tree/v8.0.0) (2026-04-17)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v7.0.2...v8.0.0)

--- a/src/ReceivingList/ReceivingList.js
+++ b/src/ReceivingList/ReceivingList.js
@@ -26,7 +26,10 @@ import {
   TitleManager,
   useStripes,
 } from '@folio/stripes/core';
-import { PersistedPaneset } from '@folio/stripes/smart-components';
+import {
+  PersistedPaneset,
+  useColumnManager,
+} from '@folio/stripes/smart-components';
 import {
   FiltersPane,
   FolioFormattedDate,
@@ -55,6 +58,11 @@ import {
 } from '../constants';
 import { useReceivingSearchContext } from '../contexts';
 import TitleDetailsContainer from '../TitleDetails';
+import {
+  RECEIVING_COLUMN_MANAGER_ID,
+  RECEIVING_COLUMN_MAPPING,
+  RECEIVING_SORTABLE_FIELDS,
+} from './constants';
 import { ExportSettingsModal } from './ExportSettingsModal';
 import { ReceivingListActionMenu } from './ReceivingListActionMenu';
 import ReceivingListFilter from './ReceivingListFilter';
@@ -63,25 +71,6 @@ import {
 } from './ReceivingListSearchConfig';
 
 const resultsPaneTitle = <FormattedMessage id="ui-receiving.meta.title" />;
-const visibleColumns = [
-  'title', 'poLine.physical.expectedReceiptDate',
-  'poLine.titleOrPackage', 'poLine.poLineNumber',
-  'poLine.receivingNote', 'locations', 'orderWorkflow',
-];
-const sortableFields = [
-  'title', 'poLine.receiptDate',
-  'poLine.titleOrPackage', 'poLine.poLineNumber',
-  'poLine.receivingNote',
-];
-const columnMapping = {
-  'title': <FormattedMessage id="ui-receiving.titles.title" />,
-  'poLine.physical.expectedReceiptDate': <FormattedMessage id="ui-receiving.title.expectedReceiptDate" />,
-  'poLine.titleOrPackage': <FormattedMessage id="ui-receiving.title.package" />,
-  'poLine.poLineNumber': <FormattedMessage id="ui-receiving.title.polNumber" />,
-  'poLine.receivingNote': <FormattedMessage id="ui-receiving.title.receivingNote" />,
-  'locations': <FormattedMessage id="ui-receiving.title.locations" />,
-  'orderWorkflow': <FormattedMessage id="ui-receiving.titles.orderWorkflow" />,
-};
 
 const getResultsFormatter = ({ isCentralRouting, search }) => ({
   'title': data => <TextLink to={`${isCentralRouting ? CENTRAL_RECEIVING_ROUTE : RECEIVING_ROUTE}/${data.id}/view${search}`}>{data.title}</TextLink>,
@@ -129,7 +118,11 @@ const ReceivingList = ({
     sortingField,
     sortingDirection,
     changeSorting,
-  ] = useLocationSorting(location, history, resetData, sortableFields);
+  ] = useLocationSorting(location, history, resetData, RECEIVING_SORTABLE_FIELDS);
+  const {
+    visibleColumns,
+    toggleColumn,
+  } = useColumnManager(RECEIVING_COLUMN_MANAGER_ID, RECEIVING_COLUMN_MAPPING);
   const { isFiltersOpened, toggleFilters } = useFiltersToogle('ui-receiving/filters');
   const [isExportModalOpened, toggleExportModal] = useModalToggle();
 
@@ -148,10 +141,12 @@ const ReceivingList = ({
       <ReceivingListActionMenu
         onToggle={onToggle}
         titlesCount={titlesCount}
+        toggleColumn={toggleColumn}
         toggleExportModal={toggleExportModal}
+        visibleColumns={visibleColumns}
       />
     );
-  }, [titlesCount, toggleExportModal]);
+  }, [titlesCount, toggleColumn, toggleExportModal, visibleColumns]);
 
   const resultsStatusMessage = (
     <NoResultsMessage
@@ -249,7 +244,7 @@ const ReceivingList = ({
                 totalCount={titlesCount}
                 contentData={titles}
                 visibleColumns={visibleColumns}
-                columnMapping={columnMapping}
+                columnMapping={RECEIVING_COLUMN_MAPPING}
                 formatter={getResultsFormatter({ search: location.search, isCentralRouting })}
                 loading={isLoading}
                 onNeedMoreData={onNeedMoreData}

--- a/src/ReceivingList/ReceivingListActionMenu.js
+++ b/src/ReceivingList/ReceivingListActionMenu.js
@@ -8,71 +8,91 @@ import {
   MenuSection,
 } from '@folio/stripes/components';
 import { IfPermission } from '@folio/stripes/core';
+import { ColumnManagerMenu } from '@folio/stripes/smart-components';
 
 import {
   CENTRAL_RECEIVING_ROUTE_CREATE,
   RECEIVING_ROUTE_CREATE,
 } from '../constants';
 import { useReceivingSearchContext } from '../contexts';
+import {
+  RECEIVING_COLUMN_MANAGER_ID,
+  RECEIVING_COLUMN_MAPPING,
+  RECEIVING_MANDATORY_COLUMNS,
+} from './constants';
 
 export const ReceivingListActionMenu = ({
   onToggle,
   titlesCount,
   toggleExportModal,
+  toggleColumn,
+  visibleColumns,
 }) => {
   const location = useLocation();
   const { isCentralRouting } = useReceivingSearchContext();
 
   return (
-    <MenuSection id="receiving-list-actions">
-      <IfPermission perm="ui-receiving.create">
-        <FormattedMessage id="stripes-smart-components.addNew">
-          {ariaLabel => (
-            <Button
-              id="clickable-new-title"
-              aria-label={ariaLabel}
-              buttonStyle="dropdownItem"
-              to={{
-                pathname: isCentralRouting ? CENTRAL_RECEIVING_ROUTE_CREATE : RECEIVING_ROUTE_CREATE,
-                search: location.search,
-              }}
-              marginBottom0
-            >
-              <Icon size="small" icon="plus-sign">
-                <FormattedMessage id="stripes-smart-components.new" />
-              </Icon>
-            </Button>
-          )}
-        </FormattedMessage>
-      </IfPermission>
+    <>
+      <MenuSection id="receiving-list-actions">
+        <IfPermission perm="ui-receiving.create">
+          <FormattedMessage id="stripes-smart-components.addNew">
+            {ariaLabel => (
+              <Button
+                id="clickable-new-title"
+                aria-label={ariaLabel}
+                buttonStyle="dropdownItem"
+                to={{
+                  pathname: isCentralRouting ? CENTRAL_RECEIVING_ROUTE_CREATE : RECEIVING_ROUTE_CREATE,
+                  search: location.search,
+                }}
+                marginBottom0
+              >
+                <Icon size="small" icon="plus-sign">
+                  <FormattedMessage id="stripes-smart-components.new" />
+                </Icon>
+              </Button>
+            )}
+          </FormattedMessage>
+        </IfPermission>
 
-      <IfPermission perm="ui-receiving.exportCSV">
-        <FormattedMessage id="ui-receiving.title.actions.exportCSV">
-          {ariaLabel => (
-            <Button
-              aria-label={ariaLabel}
-              data-testid="export-csv-button"
-              id="clickable-export-csv"
-              buttonStyle="dropdownItem"
-              onClick={() => {
-                onToggle();
-                toggleExportModal();
-              }}
-              disabled={!titlesCount}
-            >
-              <Icon size="small" icon="download">
-                <FormattedMessage id="ui-receiving.title.actions.exportCSV" />
-              </Icon>
-            </Button>
-          )}
-        </FormattedMessage>
-      </IfPermission>
-    </MenuSection>
+        <IfPermission perm="ui-receiving.exportCSV">
+          <FormattedMessage id="ui-receiving.title.actions.exportCSV">
+            {ariaLabel => (
+              <Button
+                aria-label={ariaLabel}
+                data-testid="export-csv-button"
+                id="clickable-export-csv"
+                buttonStyle="dropdownItem"
+                onClick={() => {
+                  onToggle();
+                  toggleExportModal();
+                }}
+                disabled={!titlesCount}
+              >
+                <Icon size="small" icon="download">
+                  <FormattedMessage id="ui-receiving.title.actions.exportCSV" />
+                </Icon>
+              </Button>
+            )}
+          </FormattedMessage>
+        </IfPermission>
+      </MenuSection>
+
+      <ColumnManagerMenu
+        prefix={RECEIVING_COLUMN_MANAGER_ID}
+        columnMapping={RECEIVING_COLUMN_MAPPING}
+        excludeColumns={RECEIVING_MANDATORY_COLUMNS}
+        visibleColumns={visibleColumns}
+        toggleColumn={toggleColumn}
+      />
+    </>
   );
 };
 
 ReceivingListActionMenu.propTypes = {
   onToggle: PropTypes.func.isRequired,
   titlesCount: PropTypes.number.isRequired,
+  toggleColumn: PropTypes.func.isRequired,
   toggleExportModal: PropTypes.func.isRequired,
+  visibleColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
 };

--- a/src/ReceivingList/ReceivingListActionMenu.test.js
+++ b/src/ReceivingList/ReceivingListActionMenu.test.js
@@ -3,11 +3,17 @@ import user from '@folio/jest-config-stripes/testing-library/user-event';
 import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import { ReceivingListActionMenu } from './ReceivingListActionMenu';
+import {
+  RECEIVING_COLUMNS,
+  RECEIVING_VISIBLE_COLUMNS,
+} from './constants';
 
 const defaultProps = {
   onToggle: jest.fn(),
   titlesCount: 42,
+  toggleColumn: jest.fn(),
   toggleExportModal: jest.fn(),
+  visibleColumns: RECEIVING_VISIBLE_COLUMNS,
 };
 
 const renderReceivingListActionMenu = (props = {}) => render(
@@ -21,6 +27,7 @@ const renderReceivingListActionMenu = (props = {}) => render(
 describe('ReceivingListActionMenu', () => {
   beforeEach(() => {
     defaultProps.onToggle.mockClear();
+    defaultProps.toggleColumn.mockClear();
     defaultProps.toggleExportModal.mockClear();
   });
 
@@ -37,5 +44,24 @@ describe('ReceivingListActionMenu', () => {
     await user.click(screen.getByTestId('export-csv-button'));
 
     expect(defaultProps.toggleExportModal).toHaveBeenCalled();
+  });
+
+  it('should render a column manager checkbox for every non-mandatory column', () => {
+    renderReceivingListActionMenu();
+
+    Object.values(RECEIVING_COLUMNS)
+      .filter(key => key !== RECEIVING_COLUMNS.TITLE)
+      .forEach(key => {
+        expect(document.getElementById(`receiving-list-column-checkbox-${key}`)).toBeInTheDocument();
+      });
+    expect(document.getElementById(`receiving-list-column-checkbox-${RECEIVING_COLUMNS.TITLE}`)).not.toBeInTheDocument();
+  });
+
+  it('should toggle a column when the checkbox is clicked', async () => {
+    renderReceivingListActionMenu();
+
+    await user.click(document.getElementById(`receiving-list-column-checkbox-${RECEIVING_COLUMNS.LOCATIONS}`));
+
+    expect(defaultProps.toggleColumn).toHaveBeenCalledWith(RECEIVING_COLUMNS.LOCATIONS);
   });
 });

--- a/src/ReceivingList/constants.js
+++ b/src/ReceivingList/constants.js
@@ -1,6 +1,50 @@
+import { FormattedMessage } from 'react-intl';
+
 import {
   ORDER_FORMATS,
 } from '@folio/stripes-acq-components';
+
+export const RECEIVING_COLUMNS = {
+  TITLE: 'title',
+  EXPECTED_RECEIPT_DATE: 'poLine.physical.expectedReceiptDate',
+  TITLE_OR_PACKAGE: 'poLine.titleOrPackage',
+  PO_LINE_NUMBER: 'poLine.poLineNumber',
+  RECEIVING_NOTE: 'poLine.receivingNote',
+  LOCATIONS: 'locations',
+  ORDER_WORKFLOW: 'orderWorkflow',
+};
+
+export const RECEIVING_VISIBLE_COLUMNS = [
+  RECEIVING_COLUMNS.TITLE,
+  RECEIVING_COLUMNS.EXPECTED_RECEIPT_DATE,
+  RECEIVING_COLUMNS.TITLE_OR_PACKAGE,
+  RECEIVING_COLUMNS.PO_LINE_NUMBER,
+  RECEIVING_COLUMNS.RECEIVING_NOTE,
+  RECEIVING_COLUMNS.LOCATIONS,
+  RECEIVING_COLUMNS.ORDER_WORKFLOW,
+];
+
+export const RECEIVING_MANDATORY_COLUMNS = [RECEIVING_COLUMNS.TITLE];
+
+export const RECEIVING_COLUMN_MAPPING = {
+  [RECEIVING_COLUMNS.TITLE]: <FormattedMessage id="ui-receiving.titles.title" />,
+  [RECEIVING_COLUMNS.EXPECTED_RECEIPT_DATE]: <FormattedMessage id="ui-receiving.title.expectedReceiptDate" />,
+  [RECEIVING_COLUMNS.TITLE_OR_PACKAGE]: <FormattedMessage id="ui-receiving.title.package" />,
+  [RECEIVING_COLUMNS.PO_LINE_NUMBER]: <FormattedMessage id="ui-receiving.title.polNumber" />,
+  [RECEIVING_COLUMNS.RECEIVING_NOTE]: <FormattedMessage id="ui-receiving.title.receivingNote" />,
+  [RECEIVING_COLUMNS.LOCATIONS]: <FormattedMessage id="ui-receiving.title.locations" />,
+  [RECEIVING_COLUMNS.ORDER_WORKFLOW]: <FormattedMessage id="ui-receiving.titles.orderWorkflow" />,
+};
+
+export const RECEIVING_SORTABLE_FIELDS = [
+  RECEIVING_COLUMNS.TITLE,
+  'poLine.receiptDate',
+  RECEIVING_COLUMNS.TITLE_OR_PACKAGE,
+  RECEIVING_COLUMNS.PO_LINE_NUMBER,
+  RECEIVING_COLUMNS.RECEIVING_NOTE,
+];
+
+export const RECEIVING_COLUMN_MANAGER_ID = 'receiving-list';
 
 export const FILTERS = {
   ACQUISITIONS_UNIT: 'purchaseOrder.acqUnitIds',


### PR DESCRIPTION
## Purpose

The Receiving search results list has seven columns by default, which forces horizontal scrolling on smaller displays. Users want to hide the columns they don't need, just like they can in other FOLIO apps (ui-orders, ui-inventory, ui-claims).

Reference: https://folio-org.atlassian.net/browse/UIREC-494

## Approach

Apply the standard FOLIO `useColumnManager` + `ColumnManagerMenu` pattern (already used in ui-orders, ui-inventory, ui-claims, and ui-receiving's own `TitleDetails` views) to the Receiving list:

1. **Constants extracted**: Move `visibleColumns`, `columnMapping`, and the sortable-fields list from `ReceivingList.js` into `src/ReceivingList/constants.js` (mirrors `src/Piece/constants.js`).
2. **Hook integration**: `useColumnManager('receiving-list', RECEIVING_COLUMN_MAPPING)` supplies the dynamic `visibleColumns` and `toggleColumn` to the `MultiColumnList` and to the actions menu.
3. **Mandatory column**: The "Title" column is excluded from the menu via the `excludeColumns` prop on `ColumnManagerMenu`, so the table always stays identifiable.
4. **Persistence**: Visibility is persisted in `sessionStorage` (built into `useColumnManager`) and resets on logout.

## Screenshot
<img width="1920" height="797" alt="Screenshot-Receiving-Columns" src="https://github.com/user-attachments/assets/682c30c7-8766-4ea0-ae69-2385126eb49f" />
