### PR TITLE
SI-166: Add notice when searching sequences in number generators modal without permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 8.1.0 (IN PROGRESS)
 
+* Add notice when searching sequences in number generators modal without permissions. Refs SI-166.
+
 ## [8.0.4](https://github.com/folio-org/ui-receiving/tree/v8.0.4) (2026-05-25)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v8.0.3...v8.0.4)
 

--- a/src/common/components/NumberGeneratorModal/NumberGeneratorModal.js
+++ b/src/common/components/NumberGeneratorModal/NumberGeneratorModal.js
@@ -11,6 +11,7 @@ import {
   Modal,
   ModalFooter,
 } from '@folio/stripes/components';
+import { useStripes } from '@folio/stripes/core';
 
 import {
   ACCESSION_NUMBER_GENERATOR_CODE,
@@ -31,6 +32,9 @@ const NumberGeneratorModal = ({
   const [selectedAccessionNumberSequence, setSelectedAccessionNumberSequence] = useState();
   const [selectedBarcodeSequence, setSelectedBarcodeSequence] = useState();
   const [selectedCallNumberSequence, setSelectedCallNumberSequence] = useState();
+
+  const stripes = useStripes();
+  const hasPerm = stripes.hasPerm('ui-service-interaction.numberGenerator.view');
 
   // In the case of "useAccessionNumberForCallNumber" this should do both callbacks
   const accessionNumberCallback = (val) => {
@@ -157,21 +161,26 @@ const NumberGeneratorModal = ({
       onClose={onClose}
       open={open}
     >
-      <FormattedMessage id="ui-receiving.numberGenerator.generateHelpText" />
-      {(
-        numberGeneratorData.barcode === 'onNotEditable' ||
-        numberGeneratorData.barcode === 'onEditable'
-      ) &&
-        <NumberGeneratorSelector
-          displayClearItem
-          generator={BARCODE_GENERATOR_CODE}
-          id={`${BARCODE_GENERATOR_CODE}-selector`}
-          label={<FormattedMessage id="ui-receiving.numberGenerator.barcodeSequence" />}
-          onSequenceChange={seq => setSelectedBarcodeSequence(seq)}
-          selectFirstSequenceOnMount={false}
-        />
+      {hasPerm ? (
+        <>
+          <FormattedMessage id="ui-receiving.numberGenerator.generateHelpText" />
+          {(
+            numberGeneratorData.barcode === 'onNotEditable' ||
+            numberGeneratorData.barcode === 'onEditable'
+          ) &&
+            <NumberGeneratorSelector
+              displayClearItem
+              generator={BARCODE_GENERATOR_CODE}
+              id={`${BARCODE_GENERATOR_CODE}-selector`}
+              label={<FormattedMessage id="ui-receiving.numberGenerator.barcodeSequence" />}
+              onSequenceChange={seq => setSelectedBarcodeSequence(seq)}
+              selectFirstSequenceOnMount={false}
+            />
+          }
+          {renderAccessionAndCallNumberSelectors()}
+        </>
+      ) : <FormattedMessage id="ui-receiving.numberGenerator.noPermission" />
       }
-      {renderAccessionAndCallNumberSelectors()}
     </Modal>
   );
 };

--- a/src/common/components/NumberGeneratorModal/NumberGeneratorModal.test.js
+++ b/src/common/components/NumberGeneratorModal/NumberGeneratorModal.test.js
@@ -5,6 +5,7 @@ import {
 } from '@folio/jest-config-stripes/testing-library/react';
 import user from '@folio/jest-config-stripes/testing-library/user-event';
 import { Button as MockButton } from '@folio/stripes/components';
+import { useStripes } from '@folio/stripes/core';
 
 import NumberGeneratorModal from './NumberGeneratorModal';
 
@@ -274,5 +275,33 @@ describe('Render NumberGeneratorModal', () => {
       expect(mockGenerate).toHaveBeenCalled();
       expect(mockGenerate).toHaveBeenCalledTimes(2);
     });
+  });
+});
+
+describe('Render NumberGeneratorModal without permission', () => {
+  let originalUseStripesImpl;
+
+  beforeEach(() => {
+    originalUseStripesImpl = useStripes.getMockImplementation();
+    useStripes.mockImplementation(() => ({ hasPerm: () => false }));
+  });
+
+  afterEach(() => {
+    useStripes.mockImplementation(originalUseStripesImpl);
+  });
+
+  it('should render the no permission notice instead of the selectors', () => {
+    renderNumberGeneratorModal({
+      accessionNumber: 'onEditable',
+      barcode: 'onEditable',
+      callNumber: 'onEditable',
+      useSharedNumber: false,
+    });
+
+    expect(screen.getByText('ui-receiving.numberGenerator.noPermission')).toBeInTheDocument();
+    expect(screen.queryByText('ui-receiving.numberGenerator.generateHelpText')).not.toBeInTheDocument();
+    expect(screen.queryByText('ui-receiving.numberGenerator.accessionNumberSequence')).not.toBeInTheDocument();
+    expect(screen.queryByText('ui-receiving.numberGenerator.barcodeSequence')).not.toBeInTheDocument();
+    expect(screen.queryByText('ui-receiving.numberGenerator.callNumberSequence')).not.toBeInTheDocument();
   });
 });

--- a/translations/ui-receiving/en.json
+++ b/translations/ui-receiving/en.json
@@ -64,6 +64,7 @@
   "numberGenerator.generateForRow": "Generate numbers for row {rowIndex}",
   "numberGenerator.generateNumbers": "Generate numbers",
   "numberGenerator.generateHelpText": "The selected sequences will be used to generate new numbers. Select \"Generate numbers\" to go ahead.",
+  "numberGenerator.noPermission": "You do not have the necessary permissions to use number generator sequences. Please contact your system administrator.",
 
   "filter.orderStatus": "Order status",
   "filter.vendor": "Vendor",


### PR DESCRIPTION
[SI-166](https://folio-org.atlassian.net/browse/SI-166)

When a user lacks the `ui-service-interaction.numberGenerator.view` permission, the combined number generator modal in the Receiving piece form now renders a notice instead of the (empty) sequence selectors, mirroring the existing behaviour in the shared ui-service-interaction modal (SI-139).

## Purpose

As a librarian I would like to know when I don't have the appropriate permission while using the number generator modal to search for sequences to generate numbers from. Like in the modals in Users, Organizations and Inventory, a notice _"You do not have the necessary permissions to use number generator sequences. Please contact your system administrator."_ should be displayed when I lack the appropriate permission.

This was already implemented for the shared number generator modal in SI-139 ([ui-service-interaction#168](https://github.com/folio-org/ui-service-interaction/pull/168)). However, the Receiving app does not use that shared `NumberGeneratorModal`: it has its own combined modal (for accession number, call number and item barcode) that renders the `NumberGeneratorSelector` components directly. As a result it was never covered by SI-139 and still showed empty selectors / "no results found" for users without the permission.

## Approach

A check on the `ui-service-interaction.numberGenerator.view` permission was added to the Receiving combined modal:

- If the permission is available, nothing changes
- If the permission is not available, the notice is rendered as the content of the modal instead.

## Screenshots
before (empty selectors):
<img width="1917" height="1057" alt="SI-166-before" src="https://github.com/user-attachments/assets/191549be-bc1d-402b-ba5e-89b383cfbfc0" />


after:
<img width="2559" height="1294" alt="SI-166-no-permission" src="https://github.com/user-attachments/assets/5e66c9b2-6a2c-4ac1-8309-4f3968ae0bf0" />


<!-- OPTIONAL: add "before" (empty selectors) and "after" (notice) screenshots of the combined modal for a user without the permission. -->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly _(N/A — no API/interface changes)_
  - [x] There are no breaking changes in this PR.