### PR TITLE
UIREC-504 *BREAKING* Update CQL queries to use the new indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change history for ui-receiving
 
-## 8.1.0 (IN PROGRESS)
+## 9.0.0 (IN PROGRESS)
+
+* *BREAKING* Update CQL queries to use the new indices. Refs UIREC-504.
 
 ## [8.0.4](https://github.com/folio-org/ui-receiving/tree/v8.0.4) (2026-05-25)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v8.0.3...v8.0.4)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/receiving",
-  "version": "8.0.4",
+  "version": "9.0.0",
   "description": "Description for receiving",
   "main": "index.js",
   "repository": "",

--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "regenerator-runtime": "^0.13.3"
   },
   "dependencies": {
-    "@folio/stripes-acq-components": "~7.1.0",
+    "@folio/stripes-acq-components": "~7.2.0",
     "final-form": "^4.18.2",
     "lodash": "^4.17.5",
     "prop-types": "^15.5.10",
@@ -292,7 +292,7 @@
   "optionalDependencies": {
     "@folio/plugin-find-instance": "^10.0.0",
     "@folio/plugin-find-organization": "^6.0.0",
-    "@folio/plugin-find-po-line": "^6.0.0"
+    "@folio/plugin-find-po-line": "^7.0.0"
   },
   "peerDependencies": {
     "@folio/service-interaction": "^4.0.0",

--- a/src/ReceivingList/ReceivingListSearchConfig.js
+++ b/src/ReceivingList/ReceivingListSearchConfig.js
@@ -22,15 +22,15 @@ export const searchableIndexes = [
 const buildEqualQuery = (sIndex, sQuery) => new CQLBuilder().equal(sIndex, sQuery).build();
 
 const formatSearchCqlMap = {
-  [INDEXES.PO_LINE_NUMBER]: (sIndex, sQuery) => buildEqualQuery(sIndex, sQuery),
-  [INDEXES.PO_NUMBER]: (sIndex, sQuery) => buildEqualQuery(sIndex, sQuery),
+  [INDEXES.PO_LINE_NUMBER]: buildEqualQuery,
+  [INDEXES.PO_NUMBER]: buildEqualQuery,
 };
 
 export const formatSearchCql = (sIndex, sQuery) => {
-  const formatQueryFn = formatSearchCqlMap[sIndex];
+  const formatCqlFn = formatSearchCqlMap[sIndex];
 
-  return formatQueryFn
-    ? formatQueryFn(sIndex, sQuery)
+  return formatCqlFn
+    ? formatCqlFn(sIndex, sQuery)
     : new CQLBuilder().fuzzy(sIndex, sQuery).build();
 };
 
@@ -38,11 +38,7 @@ export const getKeywordQuery = (query) => INDEXES_VALUES.reduce(
   (acc, sIndex) => {
     const formattedQuery = formatSearchCql(sIndex, query);
 
-    if (acc) {
-      return `${acc} or ${formattedQuery}`;
-    } else {
-      return formattedQuery;
-    }
+    return acc ? `${acc} or ${formattedQuery}` : formattedQuery;
   },
   '',
 );

--- a/src/ReceivingList/ReceivingListSearchConfig.js
+++ b/src/ReceivingList/ReceivingListSearchConfig.js
@@ -21,13 +21,13 @@ export const searchableIndexes = [
 
 const buildEqualQuery = (sIndex, sQuery) => new CQLBuilder().equal(sIndex, sQuery).build();
 
-const formatSearchQueryMap = {
+const formatSearchCqlMap = {
   [INDEXES.PO_LINE_NUMBER]: (sIndex, sQuery) => buildEqualQuery(sIndex, sQuery),
   [INDEXES.PO_NUMBER]: (sIndex, sQuery) => buildEqualQuery(sIndex, sQuery),
 };
 
-export const formatSearchQuery = (sIndex, sQuery) => {
-  const formatQueryFn = formatSearchQueryMap[sIndex];
+export const formatSearchCql = (sIndex, sQuery) => {
+  const formatQueryFn = formatSearchCqlMap[sIndex];
 
   return formatQueryFn
     ? formatQueryFn(sIndex, sQuery)
@@ -36,7 +36,7 @@ export const formatSearchQuery = (sIndex, sQuery) => {
 
 export const getKeywordQuery = (query) => INDEXES_VALUES.reduce(
   (acc, sIndex) => {
-    const formattedQuery = formatSearchQuery(sIndex, query);
+    const formattedQuery = formatSearchCql(sIndex, query);
 
     if (acc) {
       return `${acc} or ${formattedQuery}`;

--- a/src/ReceivingList/ReceivingListSearchConfig.js
+++ b/src/ReceivingList/ReceivingListSearchConfig.js
@@ -1,26 +1,47 @@
-const indexes = [
-  'title',
-  'poLine.titleOrPackage',
-  'productIds',
-  'purchaseOrder.poNumber',
-  'poLine.poLineNumber',
-  'poLine.vendorDetail.referenceNumbers',
-];
+import { CQLBuilder } from '@folio/stripes-acq-components';
+
+const INDEXES = {
+  TITLE: 'title',
+  TITLE_OR_PACKAGE: 'poLine.titleOrPackage',
+  PRODUCT_IDS: 'productIds',
+  PO_NUMBER: 'purchaseOrder.poNumber',
+  PO_LINE_NUMBER: 'poLine.poLineNumber',
+  VENDOR_DETAIL_REFERENCE_NUMBERS: 'poLine.vendorDetail.referenceNumbers',
+};
+
+const INDEXES_VALUES = Object.values(INDEXES);
 
 export const searchableIndexes = [
   {
     labelId: 'ui-receiving.search.keyword',
     value: '',
   },
-  ...indexes.map(index => ({ labelId: `ui-receiving.search.${index}`, value: index })),
+  ...INDEXES_VALUES.map(index => ({ labelId: `ui-receiving.search.${index}`, value: index })),
 ];
 
-export const getKeywordQuery = query => indexes.reduce(
+const buildEqualQuery = (sIndex, sQuery) => new CQLBuilder().equal(sIndex, sQuery).build();
+
+const formatSearchQueryMap = {
+  [INDEXES.PO_LINE_NUMBER]: (sIndex, sQuery) => buildEqualQuery(sIndex, sQuery),
+  [INDEXES.PO_NUMBER]: (sIndex, sQuery) => buildEqualQuery(sIndex, sQuery),
+};
+
+export const formatSearchQuery = (sIndex, sQuery) => {
+  const formatQueryFn = formatSearchQueryMap[sIndex];
+
+  return formatQueryFn
+    ? formatQueryFn(sIndex, sQuery)
+    : new CQLBuilder().fuzzy(sIndex, sQuery).build();
+};
+
+export const getKeywordQuery = (query) => INDEXES_VALUES.reduce(
   (acc, sIndex) => {
+    const formattedQuery = formatSearchQuery(sIndex, query);
+
     if (acc) {
-      return `${acc} or ${sIndex}=="*${query}*"`;
+      return `${acc} or ${formattedQuery}`;
     } else {
-      return `${sIndex}=="*${query}*"`;
+      return formattedQuery;
     }
   },
   '',

--- a/src/ReceivingList/ReceivingListSearchConfig.test.js
+++ b/src/ReceivingList/ReceivingListSearchConfig.test.js
@@ -1,7 +1,20 @@
+import { CQLBuilder } from '@folio/stripes-acq-components';
+
 import { getKeywordQuery } from './ReceivingListSearchConfig';
+
+const { EQUAL, FUZZY } = CQLBuilder.OPERATORS;
 
 test('getKeywordQuery', () => {
   const query = getKeywordQuery('query');
 
-  expect(query).toBe('title=="*query*" or poLine.titleOrPackage=="*query*" or productIds=="*query*" or purchaseOrder.poNumber=="*query*" or poLine.poLineNumber=="*query*" or poLine.vendorDetail.referenceNumbers=="*query*"');
+  expect(query).toBe(
+    [
+      `title${FUZZY}"query"`,
+      `poLine.titleOrPackage${FUZZY}"query"`,
+      `productIds${FUZZY}"query"`,
+      `purchaseOrder.poNumber${EQUAL}"query"`,
+      `poLine.poLineNumber${EQUAL}"query"`,
+      `poLine.vendorDetail.referenceNumbers${FUZZY}"query"`,
+    ].join(' or '),
+  );
 });

--- a/src/ReceivingList/utils.js
+++ b/src/ReceivingList/utils.js
@@ -27,7 +27,7 @@ import {
   ORDER_FORMAT_MATERIAL_TYPE_MAP,
 } from './constants';
 import {
-  formatSearchQuery,
+  formatSearchCql,
   getKeywordQuery,
 } from './ReceivingListSearchConfig';
 
@@ -126,7 +126,7 @@ const buildLocationsQuery = (filterValue) => {
 
 const getSearchQuery = (query, qindex) => {
   if (qindex) {
-    return formatSearchQuery(qindex, query);
+    return formatSearchCql(qindex, query);
   }
 
   return getKeywordQuery(query);

--- a/src/ReceivingList/utils.js
+++ b/src/ReceivingList/utils.js
@@ -8,7 +8,7 @@ import {
   buildDateRangeQuery,
   buildDateTimeRangeQuery,
   buildFilterQuery,
-  buildMultiSelectionCqlQuery,
+  buildMultiOptionCqlQuery,
   buildSortingQuery,
   connectQuery,
   CQLBuilder,
@@ -119,8 +119,8 @@ export const fetchConsortiumOrderLineLocations = (ky, stripes) => (orderLines) =
 
 const buildLocationsQuery = (filterValue) => {
   return [
-    buildMultiSelectionCqlQuery(FILTERS.LOCATION, filterValue, { modifiers: [{ name: '@locationId' }] }),
-    buildMultiSelectionCqlQuery('poLine.searchLocations', filterValue),
+    buildMultiOptionCqlQuery(FILTERS.LOCATION, filterValue, { modifiers: [{ name: '@locationId' }] }),
+    buildMultiOptionCqlQuery('poLine.searchLocations', filterValue),
   ].join(` ${CQLBuilder.OPERATORS.OR} `);
 };
 
@@ -170,8 +170,8 @@ export const buildTitlesQuery = (queryParams, options) => {
       [FILTERS.RECEIVED_DATE]: buildDateRangeQuery.bind(null, [FILTERS.RECEIVED_DATE]),
       [FILTERS.RECEIPT_DUE]: buildDateRangeQuery.bind(null, [FILTERS.RECEIPT_DUE]),
       [FILTERS.LOCATION]: (filterValue) => buildLocationsQuery(filterValue),
-      [FILTERS.POL_TAGS]: buildMultiSelectionCqlQuery.bind(null, FILTERS.POL_TAGS),
-      [FILTERS.ACQUISITIONS_UNIT]: buildMultiSelectionCqlQuery.bind(null, FILTERS.ACQUISITIONS_UNIT),
+      [FILTERS.POL_TAGS]: buildMultiOptionCqlQuery.bind(null, FILTERS.POL_TAGS),
+      [FILTERS.ACQUISITIONS_UNIT]: buildMultiOptionCqlQuery.bind(null, FILTERS.ACQUISITIONS_UNIT),
     },
     true,
     options,

--- a/src/ReceivingList/utils.js
+++ b/src/ReceivingList/utils.js
@@ -5,12 +5,13 @@ import uniq from 'lodash/uniq';
 
 import {
   batchRequest,
-  buildArrayFieldQuery,
   buildDateRangeQuery,
   buildDateTimeRangeQuery,
   buildFilterQuery,
+  buildMultiSelectionCqlQuery,
   buildSortingQuery,
   connectQuery,
+  CQLBuilder,
   fetchConsortiumBatchHoldings,
   getConsortiumCentralTenantKy,
   HOLDINGS_API,
@@ -25,7 +26,10 @@ import {
   FILTERS,
   ORDER_FORMAT_MATERIAL_TYPE_MAP,
 } from './constants';
-import { getKeywordQuery } from './ReceivingListSearchConfig';
+import {
+  formatSearchQuery,
+  getKeywordQuery,
+} from './ReceivingListSearchConfig';
 
 export const fetchTitleOrderLines = (ky, titles, fetchedOrderLinesMap) => {
   const orderLineIds = titles
@@ -113,6 +117,21 @@ export const fetchConsortiumOrderLineLocations = (ky, stripes) => (orderLines) =
     });
 };
 
+const buildLocationsQuery = (filterValue) => {
+  return [
+    buildMultiSelectionCqlQuery(FILTERS.LOCATION, filterValue, { modifiers: [{ name: '@locationId' }] }),
+    buildMultiSelectionCqlQuery('poLine.searchLocations', filterValue),
+  ].join(` ${CQLBuilder.OPERATORS.OR} `);
+};
+
+const getSearchQuery = (query, qindex) => {
+  if (qindex) {
+    return formatSearchQuery(qindex, query);
+  }
+
+  return getKeywordQuery(query);
+};
+
 export const buildTitlesQuery = (queryParams, options) => {
   let materialTypeFilterQuery;
 
@@ -141,13 +160,7 @@ export const buildTitlesQuery = (queryParams, options) => {
 
   const queryParamsFilterQuery = buildFilterQuery(
     queryParams,
-    (query, qindex) => {
-      if (qindex) {
-        return `(${qindex}=="*${query}*")`;
-      }
-
-      return getKeywordQuery(query);
-    },
+    getSearchQuery,
     {
       [FILTERS.DATE_CREATED]: buildDateTimeRangeQuery.bind(null, [FILTERS.DATE_CREATED]),
       [FILTERS.DATE_UPDATED]: buildDateTimeRangeQuery.bind(null, [FILTERS.DATE_UPDATED]),
@@ -156,13 +169,9 @@ export const buildTitlesQuery = (queryParams, options) => {
       [FILTERS.EXPECTED_RECEIPT_DATE]: buildDateRangeQuery.bind(null, [FILTERS.EXPECTED_RECEIPT_DATE]),
       [FILTERS.RECEIVED_DATE]: buildDateRangeQuery.bind(null, [FILTERS.RECEIVED_DATE]),
       [FILTERS.RECEIPT_DUE]: buildDateRangeQuery.bind(null, [FILTERS.RECEIPT_DUE]),
-      [FILTERS.LOCATION]: (filterValue) => `(${
-        [FILTERS.LOCATION, 'poLine.searchLocationIds']
-          .map((filterKey) => buildArrayFieldQuery(filterKey, filterValue))
-          .join(' or ')
-      })`,
-      [FILTERS.POL_TAGS]: buildArrayFieldQuery.bind(null, [FILTERS.POL_TAGS]),
-      [FILTERS.ACQUISITIONS_UNIT]: buildArrayFieldQuery.bind(null, [FILTERS.ACQUISITIONS_UNIT]),
+      [FILTERS.LOCATION]: (filterValue) => buildLocationsQuery(filterValue),
+      [FILTERS.POL_TAGS]: buildMultiSelectionCqlQuery.bind(null, FILTERS.POL_TAGS),
+      [FILTERS.ACQUISITIONS_UNIT]: buildMultiSelectionCqlQuery.bind(null, FILTERS.ACQUISITIONS_UNIT),
     },
     true,
     options,

--- a/src/ReceivingList/utils.test.js
+++ b/src/ReceivingList/utils.test.js
@@ -1,5 +1,6 @@
 import {
   CONSORTIUM_LOCATIONS_API,
+  CQLBuilder,
   HOLDINGS_API,
   LIMIT_MAX,
   LINES_API,
@@ -25,6 +26,8 @@ jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
   getConsortiumCentralTenantId: jest.fn(() => 'centralTenantId'),
 }));
+
+const { FUZZY, OR } = CQLBuilder.OPERATORS;
 
 describe('ReceivingList utils', () => {
   describe('fetchTitleOrderLines', () => {
@@ -252,7 +255,12 @@ describe('ReceivingList utils', () => {
     it('should return search query based on location filter', () => {
       const query = buildTitlesQuery({ [FILTERS.LOCATION]: 'locationId' });
 
-      expect(query).toContain('(poLine.locations=="*locationId*" or poLine.searchLocationIds=="*locationId*")');
+      expect(query).toContain(
+        [
+          `poLine.locations ${FUZZY}/@locationId "locationId"`,
+          `poLine.searchLocations${FUZZY}"locationId"`,
+        ].join(` ${OR} `),
+      );
     });
   });
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIREC-504

Requires https://github.com/folio-org/stripes-acq-components/pull/951

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

- Use `buildMultiOptionCqlQuery ` to update CQL with relation modifiers;
- Update relations for search indices;
- Remove wrapping the filter value in wildcards;
- Update tests.