### PR TITLE
UIREC-492 Add column manager to the Receive table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * Standardize scrollbar behavior of the Receive table. Refs UIREC-493.
 * Add notice when searching sequences in number generators modal without permissions. Refs SI-166.
+* Standardize scrollbar behavior of the Receive table. Refs UIREC-493.
+* Add notice when searching sequences in number generators modal without permissions. Refs SI-166.
+* *BREAKING* Update CQL queries to use the new indices. Refs UIREC-504.
 * Add column manager to the Receive table. Refs UIREC-492.
 
 ## [8.0.4](https://github.com/folio-org/ui-receiving/tree/v8.0.4) (2026-05-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 8.1.0 (IN PROGRESS)
 
+* Add column manager to the Receive table. Refs UIREC-492.
 * Standardize scrollbar behavior of the Receive table. Refs UIREC-493.
 * Add notice when searching sequences in number generators modal without permissions. Refs SI-166.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 8.1.0 (IN PROGRESS)
 
-* Add column manager to the Receive table. Refs UIREC-492.
 * Standardize scrollbar behavior of the Receive table. Refs UIREC-493.
 * Add notice when searching sequences in number generators modal without permissions. Refs SI-166.
+* Add column manager to the Receive table. Refs UIREC-492.
 
 ## [8.0.4](https://github.com/folio-org/ui-receiving/tree/v8.0.4) (2026-05-25)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v8.0.3...v8.0.4)

--- a/src/Piece/constants.js
+++ b/src/Piece/constants.js
@@ -136,8 +136,28 @@ export const PIECE_COLUMN_BASE_FORMATTER = {
   [PIECE_COLUMNS.status]: record => record.receivingStatus || <NoValue />,
 };
 
+export const RECEIVE_PIECE_VISIBLE_COLUMNS = [
+  PIECE_COLUMNS.displaySummary,
+  PIECE_COLUMNS.enumeration,
+  PIECE_COLUMNS.chronology,
+  PIECE_COLUMNS.copyNumber,
+  PIECE_COLUMNS.accessionNumber,
+  PIECE_COLUMNS.barcode,
+  PIECE_COLUMNS.format,
+  PIECE_COLUMNS.receiptDate,
+  PIECE_COLUMNS.request,
+  PIECE_COLUMNS.comment,
+  PIECE_COLUMNS.location,
+  PIECE_COLUMNS.itemStatus,
+  PIECE_COLUMNS.callNumber,
+  PIECE_COLUMNS.isCreateItem,
+  PIECE_COLUMNS.displayOnHolding,
+  PIECE_COLUMNS.supplement,
+];
+
 export const EXPECTED_PIECE_COLUMN_MAPPING = pick(PIECE_COLUMN_MAPPING, EXPECTED_PIECE_VISIBLE_COLUMNS);
 export const RECEIVED_PIECE_COLUMN_MAPPING = pick(PIECE_COLUMN_MAPPING, RECEIVED_PIECE_VISIBLE_COLUMNS);
+export const RECEIVE_PIECE_COLUMN_MAPPING = pick(PIECE_COLUMN_MAPPING, RECEIVE_PIECE_VISIBLE_COLUMNS);
 export const UNRECEIVABLE_PIECE_COLUMN_MAPPING = {
   ...pick(PIECE_COLUMN_MAPPING, UNRECEIVABLE_PIECE_VISIBLE_COLUMNS),
   [PIECE_COLUMNS.callNumber]: <FormattedMessage id="ui-receiving.piece.callNumber" />,

--- a/src/TitleReceive/TitleReceive.js
+++ b/src/TitleReceive/TitleReceive.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { FieldArray } from 'react-final-form-arrays';
 
 import stripesFinalForm from '@folio/stripes/final-form';
@@ -13,14 +13,24 @@ import {
   Paneset,
 } from '@folio/stripes/components';
 import {
+  ColumnManagerMenu,
+  useColumnManager,
+} from '@folio/stripes/smart-components';
+import {
   FormFooter,
   handleKeyCommand,
 } from '@folio/stripes-acq-components';
 
 import { LineLocationsView } from '../common/components';
 import { setLocationValueFormMutator } from '../common/utils';
+import {
+  PIECE_COLUMNS,
+  RECEIVE_PIECE_COLUMN_MAPPING,
+} from '../Piece';
 import { TitleReceiveList } from './TitleReceiveList';
 import css from './TitleReceive.css';
+
+const COLUMN_MANAGER_ID = 'receive-piece-column-manager';
 
 const FIELD_NAME = 'receivedItems';
 
@@ -42,6 +52,21 @@ const TitleReceive = ({
   submitting,
   values,
 }) => {
+  const {
+    visibleColumns,
+    toggleColumn,
+  } = useColumnManager(COLUMN_MANAGER_ID, RECEIVE_PIECE_COLUMN_MAPPING);
+
+  const renderActionMenu = useCallback(() => (
+    <ColumnManagerMenu
+      prefix="receive-piece"
+      columnMapping={RECEIVE_PIECE_COLUMN_MAPPING}
+      visibleColumns={visibleColumns}
+      toggleColumn={toggleColumn}
+      excludeColumns={[PIECE_COLUMNS.displaySummary]}
+    />
+  ), [visibleColumns, toggleColumn]);
+
   const isReceiveDisabled = useMemo(() => {
     return isLoading || (isPiecesChunksExhausted && !values[FIELD_NAME].some(({ checked }) => checked));
   }, [isLoading, isPiecesChunksExhausted, values]);
@@ -93,6 +118,7 @@ const TitleReceive = ({
       >
         <Paneset>
           <Pane
+            actionMenu={renderActionMenu}
             defaultWidth="fill"
             dismissible
             footer={paneFooter}
@@ -129,6 +155,7 @@ const TitleReceive = ({
                     poLineLocationIds,
                     selectLocation: form.mutators.setLocationValue,
                     toggleCheckedAll: form.mutators.toggleCheckedAll,
+                    visibleColumns,
                   }}
                 />
               </div>

--- a/src/TitleReceive/TitleReceive.test.js
+++ b/src/TitleReceive/TitleReceive.test.js
@@ -8,6 +8,7 @@ import { MemoryRouter } from 'react-router-dom';
 import {
   fireEvent,
   render,
+  screen,
 } from '@folio/jest-config-stripes/testing-library/react';
 
 import {
@@ -180,6 +181,23 @@ describe('Receiving title', () => {
           expect(document.getElementById(`receive-piece-column-checkbox-${key}`)).toBeInTheDocument();
         });
       expect(document.getElementById(`receive-piece-column-checkbox-${PIECE_COLUMNS.displaySummary}`)).not.toBeInTheDocument();
+    });
+
+    it('should keep a hidden column field value in form state and restore it when shown again', () => {
+      renderTitleReceive();
+
+      // The barcode field is visible by default and shows its initial value.
+      expect(screen.getByDisplayValue('10001')).toBeInTheDocument();
+
+      fireEvent.click(document.querySelector('[data-test-pane-header-actions-button]'));
+
+      // Hiding the barcode column unmounts the field, but its value is preserved.
+      fireEvent.click(document.getElementById(`receive-piece-column-checkbox-${PIECE_COLUMNS.barcode}`));
+      expect(screen.queryByDisplayValue('10001')).not.toBeInTheDocument();
+
+      // Showing it again restores the field with the original value.
+      fireEvent.click(document.getElementById(`receive-piece-column-checkbox-${PIECE_COLUMNS.barcode}`));
+      expect(screen.getByDisplayValue('10001')).toBeInTheDocument();
     });
   });
 });

--- a/src/TitleReceive/TitleReceive.test.js
+++ b/src/TitleReceive/TitleReceive.test.js
@@ -5,8 +5,15 @@ import {
 } from 'react-query';
 import { MemoryRouter } from 'react-router-dom';
 
-import { render } from '@folio/jest-config-stripes/testing-library/react';
+import {
+  fireEvent,
+  render,
+} from '@folio/jest-config-stripes/testing-library/react';
 
+import {
+  PIECE_COLUMNS,
+  RECEIVE_PIECE_VISIBLE_COLUMNS,
+} from '../Piece/constants';
 import TitleReceive from './TitleReceive';
 
 jest.mock('@folio/stripes/components', () => ({
@@ -158,6 +165,21 @@ describe('Receiving title', () => {
       });
 
       expect(getByText(submitButtonLabel)).toBeInTheDocument();
+    });
+  });
+
+  describe('Column manager', () => {
+    it('should render a column checkbox for every non-mandatory column', () => {
+      renderTitleReceive();
+
+      fireEvent.click(document.querySelector('[data-test-pane-header-actions-button]'));
+
+      RECEIVE_PIECE_VISIBLE_COLUMNS
+        .filter((key) => key !== PIECE_COLUMNS.displaySummary)
+        .forEach((key) => {
+          expect(document.getElementById(`receive-piece-column-checkbox-${key}`)).toBeInTheDocument();
+        });
+      expect(document.getElementById(`receive-piece-column-checkbox-${PIECE_COLUMNS.displaySummary}`)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/TitleReceive/TitleReceiveList.js
+++ b/src/TitleReceive/TitleReceiveList.js
@@ -60,26 +60,6 @@ import {
 } from '../Piece';
 import { useFieldArrowNavigation } from './useFieldArrowNavigation';
 
-const visibleColumns = [
-  'checked',
-  PIECE_COLUMNS.displaySummary,
-  PIECE_COLUMNS.enumeration,
-  PIECE_COLUMNS.chronology,
-  PIECE_COLUMNS.copyNumber,
-  PIECE_COLUMNS.accessionNumber,
-  PIECE_COLUMNS.barcode,
-  PIECE_COLUMNS.format,
-  PIECE_COLUMNS.receiptDate,
-  PIECE_COLUMNS.request,
-  PIECE_COLUMNS.comment,
-  PIECE_COLUMNS.location,
-  PIECE_COLUMNS.itemStatus,
-  PIECE_COLUMNS.callNumber,
-  PIECE_COLUMNS.isCreateItem,
-  PIECE_COLUMNS.displayOnHolding,
-  PIECE_COLUMNS.supplement,
-];
-
 // Only the fields actually consumed by cell formatters or CreateItemField.
 // Form-bound values (displaySummary, enumeration, comment, etc.) are resolved
 // via <Field name> and must be excluded so MCL's dataChangedOrLess() does not
@@ -328,6 +308,7 @@ export const TitleReceiveList = ({ fields, props }) => {
     toggleCheckedAll = defaultListProps.toggleCheckedAll,
     locations = defaultListProps.locations,
     poLineLocationIds = defaultListProps.poLineLocationIds,
+    visibleColumns = [],
   } = props || {};
 
   const eventEmitter = useEventEmitter();
@@ -412,7 +393,7 @@ export const TitleReceiveList = ({ fields, props }) => {
   }, [fields.value]);
 
   const visibleColumnsWithActions = useMemo(() => {
-    const vcwa = [...visibleColumns];
+    const vcwa = ['checked', ...visibleColumns];
 
     if (
       numberGeneratorData[ACCESSION_NUMBER_SETTING] === GENERATOR_ON ||
@@ -427,7 +408,7 @@ export const TitleReceiveList = ({ fields, props }) => {
     }
 
     return vcwa;
-  }, [numberGeneratorData]);
+  }, [numberGeneratorData, visibleColumns]);
 
   return (
     <>

--- a/src/TitleReceive/TitleReceiveList.test.js
+++ b/src/TitleReceive/TitleReceiveList.test.js
@@ -22,6 +22,7 @@ import {
   GENERATOR_ON,
   GENERATOR_OFF,
 } from '../common/constants';
+import { RECEIVE_PIECE_VISIBLE_COLUMNS } from '../Piece/constants';
 import { TitleReceiveList } from './TitleReceiveList';
 
 jest.mock('../common/hooks', () => ({
@@ -48,6 +49,7 @@ const defaultProps = {
     toggleCheckedAll: jest.fn(),
     poLineLocationIds: [],
     locations: [],
+    visibleColumns: RECEIVE_PIECE_VISIBLE_COLUMNS,
   },
 };
 
@@ -72,6 +74,28 @@ describe('Render TitleReceiveList', () => {
       expect.objectContaining({ autosize: true }),
       expect.anything(),
     );
+  });
+
+  it('should prepend the checked column to the visibleColumns from props', () => {
+    renderTitleReceiveList();
+
+    const { visibleColumns } = MultiColumnList.mock.calls.at(-1)[0];
+
+    expect(visibleColumns[0]).toBe('checked');
+    expect(visibleColumns).not.toContain('actions');
+  });
+
+  it('should pass only the checked column and the provided visibleColumns when some are hidden', () => {
+    renderTitleReceiveList({
+      props: {
+        ...defaultProps.props,
+        visibleColumns: ['displaySummary', 'barcode'],
+      },
+    });
+
+    const { visibleColumns } = MultiColumnList.mock.calls.at(-1)[0];
+
+    expect(visibleColumns).toEqual(['checked', 'displaySummary', 'barcode']);
   });
 
   it('should not show the number generator button if generator settings are off', async () => {


### PR DESCRIPTION
## Purpose

The Receive page renders the pieces to receive as a wide, editable table (16+ columns), which forces horizontal scrolling on smaller displays. Users want to hide the columns they don't need, just like they can in other FOLIO apps (ui-orders, ui-inventory, ui-claims) and in the Receiving results list (UIREC-494).

Reference: https://folio-org.atlassian.net/browse/UIREC-492

## Approach

Apply the standard FOLIO `useColumnManager` + `ColumnManagerMenu` pattern (already used in ui-orders, ui-inventory, ui-claims, and ui-receiving's own list and detail views) to the Receive form:

1. **Constants added**: `RECEIVE_PIECE_VISIBLE_COLUMNS` and `RECEIVE_PIECE_COLUMN_MAPPING` in `src/Piece/constants.js` (mirrors the existing expected/received piece column sets).
2. **Hook integration**: `useColumnManager('receive-piece-column-manager', RECEIVE_PIECE_COLUMN_MAPPING)` supplies the dynamic `visibleColumns` and `toggleColumn`. The menu is rendered as the pane `actionMenu` via `ColumnManagerMenu`.
3. **Always-on columns**: The display-summary column is excluded from the menu via the `excludeColumns` prop, so the table stays identifiable, and the selection ("checked") column is always kept as the first column.
4. **Persistence**: Column visibility is persisted in `sessionStorage` (built into `useColumnManager`) and resets on logout.

This complements UIREC-493, which standardized the scrollbar behavior of the same Receive table.

## Screenshot
<img width="3840" height="2160" alt="image-20260312-202503" src="https://github.com/user-attachments/assets/3815d12f-50f4-41b5-8f4e-667a18f5b4db" />
