### PR TITLE
UIREC-499 Add Vendor column to Receiving list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add notice when searching sequences in number generators modal without permissions. Refs SI-166.
 * Add column manager to the Receive table. Refs UIREC-492.
 * Use `crossTenant` from the receiving search context to distinguish between central and local resources when fetching data. Refs UIREC-509.
+* Add "Vendor" column to the Receiving results list. Refs UIREC-499.
 
 ## [8.0.4](https://github.com/folio-org/ui-receiving/tree/v8.0.4) (2026-05-25)
 [Full Changelog](https://github.com/folio-org/ui-receiving/compare/v8.0.3...v8.0.4)

--- a/src/ReceivingList/ReceivingList.js
+++ b/src/ReceivingList/ReceivingList.js
@@ -74,6 +74,7 @@ const resultsPaneTitle = <FormattedMessage id="ui-receiving.meta.title" />;
 
 const getResultsFormatter = ({ isCentralRouting, search }) => ({
   'title': data => <TextLink to={`${isCentralRouting ? CENTRAL_RECEIVING_ROUTE : RECEIVING_ROUTE}/${data.id}/view${search}`}>{data.title}</TextLink>,
+  'vendor': data => get(data, 'poLine.vendor') || <NoValue />,
   'poLine.physical.expectedReceiptDate': data => <FolioFormattedDate value={get(data, 'poLine.physical.expectedReceiptDate')} />,
   'poLine.titleOrPackage': data => (get(data, 'poLine.isPackage') ? get(data, 'poLine.titleOrPackage') : <NoValue />),
   'poLine.poLineNumber': data => get(data, 'poLine.poLineNumber'),

--- a/src/ReceivingList/ReceivingList.test.js
+++ b/src/ReceivingList/ReceivingList.test.js
@@ -99,6 +99,16 @@ describe('Given Receiving List', () => {
     });
   });
 
+  it('Than it should display the vendor name as the second column', () => {
+    renderReceivingList({
+      titles: [{ title: 'Title with a vendor', poLine: { vendor: 'Amazon.com' } }],
+      titlesCount: 1,
+    });
+
+    expect(screen.getAllByRole('columnheader')[1]).toHaveTextContent('ui-receiving.title.vendor');
+    expect(screen.getByText('Amazon.com')).toBeInTheDocument();
+  });
+
   it('should handle default props and render empty list', () => {
     renderReceivingList({
       isLoading: undefined,

--- a/src/ReceivingList/ReceivingListContainer.js
+++ b/src/ReceivingList/ReceivingListContainer.js
@@ -39,28 +39,45 @@ const ReceivingListContainer = () => {
   const fetchReferences = useCallback(async (titles, ky) => {
     const orderLinesResponse = await fetchTitleOrderLines(ky, titles, {});
 
-    const holdingsResponse = await (
-      crossTenant
-        ? fetchConsortiumOrderLineHoldings(ky, stripes)
-        : fetchOrderLineHoldings(ky)
-    )(orderLinesResponse);
+    const fetchHoldingsAndLocations = async () => {
+      const holdingsResponse = await (
+        crossTenant
+          ? fetchConsortiumOrderLineHoldings(ky, stripes)
+          : fetchOrderLineHoldings(ky)
+      )(orderLinesResponse);
 
-    const locationsResponse = await (
-      crossTenant
-        ? fetchConsortiumOrderLineLocations(ky, stripes)
-        : fetchOrderLineLocations(ky)
-    )(
-      [
-        ...orderLinesResponse,
-        ...holdingsResponse
-          .map(({ permanentLocationId: locationId }) => ({
-            locations: [{ locationId }],
-          })),
-      ],
-      {},
-    );
-    const linesOrdersResponse = await fetchLinesOrders(ky, orderLinesResponse, {});
-    const vendorsResponse = await fetchOrdersVendors(ky, linesOrdersResponse);
+      const locationsResponse = await (
+        crossTenant
+          ? fetchConsortiumOrderLineLocations(ky, stripes)
+          : fetchOrderLineLocations(ky)
+      )(
+        [
+          ...orderLinesResponse,
+          ...holdingsResponse
+            .map(({ permanentLocationId: locationId }) => ({
+              locations: [{ locationId }],
+            })),
+        ],
+        {},
+      );
+
+      return { holdingsResponse, locationsResponse };
+    };
+
+    const fetchOrdersAndVendors = async () => {
+      const linesOrdersResponse = await fetchLinesOrders(ky, orderLinesResponse, {});
+      const vendorsResponse = await fetchOrdersVendors(ky, linesOrdersResponse);
+
+      return { linesOrdersResponse, vendorsResponse };
+    };
+
+    const [
+      { holdingsResponse, locationsResponse },
+      { linesOrdersResponse, vendorsResponse },
+    ] = await Promise.all([
+      fetchHoldingsAndLocations(),
+      fetchOrdersAndVendors(),
+    ]);
 
     const locationsMap = locationsResponse.reduce((acc, locationItem) => {
       acc[locationItem.id] = locationItem;

--- a/src/ReceivingList/ReceivingListContainer.js
+++ b/src/ReceivingList/ReceivingListContainer.js
@@ -18,6 +18,7 @@ import {
   fetchLinesOrders,
   fetchOrderLineHoldings,
   fetchOrderLineLocations,
+  fetchOrdersVendors,
   fetchTitleOrderLines,
 } from './utils';
 
@@ -59,6 +60,7 @@ const ReceivingListContainer = () => {
       {},
     );
     const linesOrdersResponse = await fetchLinesOrders(ky, orderLinesResponse, {});
+    const vendorsResponse = await fetchOrdersVendors(ky, linesOrdersResponse);
 
     const locationsMap = locationsResponse.reduce((acc, locationItem) => {
       acc[locationItem.id] = locationItem;
@@ -78,6 +80,12 @@ const ReceivingListContainer = () => {
       return acc;
     }, {});
 
+    const vendorsMap = vendorsResponse.reduce((acc, vendor) => {
+      acc[vendor.id] = vendor;
+
+      return acc;
+    }, {});
+
     const orderLinesMap = orderLinesResponse.reduce((acc, orderLine) => {
       acc[orderLine.id] = {
         ...orderLine,
@@ -92,6 +100,7 @@ const ReceivingListContainer = () => {
           return origLocation?.name ?? invalidReferenceMessage;
         }),
         orderWorkflow: ordersMap[orderLine.purchaseOrderId]?.workflowStatus,
+        vendor: vendorsMap[ordersMap[orderLine.purchaseOrderId]?.vendor]?.name,
       };
 
       return acc;

--- a/src/ReceivingList/ReceivingListContainer.test.js
+++ b/src/ReceivingList/ReceivingListContainer.test.js
@@ -12,6 +12,7 @@ import {
   fetchLinesOrders,
   fetchOrderLineHoldings,
   fetchOrderLineLocations,
+  fetchOrdersVendors,
   fetchTitleOrderLines,
 } from './utils';
 
@@ -29,6 +30,7 @@ jest.mock('./utils', () => ({
   fetchLinesOrders: jest.fn(),
   fetchOrderLineHoldings: jest.fn(),
   fetchOrderLineLocations: jest.fn(),
+  fetchOrdersVendors: jest.fn(),
   fetchTitleOrderLines: jest.fn(),
 }));
 
@@ -44,6 +46,24 @@ describe('ReceivingListContainer', () => {
     title: 'Multi-line titles #2',
     poLineId: '3e1a947f-a605-41b8-839c-7929f02ef911',
   }];
+  const vendor = {
+    id: 'e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1',
+    name: 'Amazon.com',
+  };
+  const order = {
+    id: '17d5d47c-19a4-4ba0-b6bf-2b8f5e6c4e11',
+    vendor: vendor.id,
+    workflowStatus: 'Open',
+  };
+  const location = {
+    id: '758258bc-ecc1-41b8-abca-f7b610822ffd',
+    name: 'Main Library',
+  };
+  const orderLine = {
+    id: titles[0].poLineId,
+    purchaseOrderId: order.id,
+    locations: [{ locationId: location.id }],
+  };
 
   beforeEach(() => {
     fetchConsortiumOrderLineHoldings
@@ -61,6 +81,9 @@ describe('ReceivingListContainer', () => {
     fetchOrderLineLocations
       .mockClear()
       .mockReturnValue(() => []);
+    fetchOrdersVendors
+      .mockClear()
+      .mockReturnValue([]);
     fetchTitleOrderLines
       .mockClear()
       .mockReturnValue([]);
@@ -83,5 +106,21 @@ describe('ReceivingListContainer', () => {
     expect(fetchTitleOrderLines).toHaveBeenCalled();
     expect(fetchLinesOrders).toHaveBeenCalled();
     expect(fetchOrderLineLocations).toHaveBeenCalled();
+  });
+
+  it('should resolve vendor and location names of the fetched order lines', async () => {
+    fetchTitleOrderLines.mockReturnValue([orderLine]);
+    fetchOrderLineLocations.mockReturnValue(() => [location]);
+    fetchLinesOrders.mockReturnValue([order]);
+    fetchOrdersVendors.mockReturnValue([vendor]);
+
+    renderReceivingListContainer();
+
+    const { orderLinesMap } = await useReceiving.mock.calls[0][0].fetchReferences(titles);
+
+    expect(orderLinesMap[orderLine.id]).toEqual(expect.objectContaining({
+      locations: [location.name],
+      vendor: vendor.name,
+    }));
   });
 });

--- a/src/ReceivingList/constants.js
+++ b/src/ReceivingList/constants.js
@@ -6,6 +6,7 @@ import {
 
 export const RECEIVING_COLUMNS = {
   TITLE: 'title',
+  VENDOR: 'vendor',
   EXPECTED_RECEIPT_DATE: 'poLine.physical.expectedReceiptDate',
   TITLE_OR_PACKAGE: 'poLine.titleOrPackage',
   PO_LINE_NUMBER: 'poLine.poLineNumber',
@@ -16,6 +17,7 @@ export const RECEIVING_COLUMNS = {
 
 export const RECEIVING_VISIBLE_COLUMNS = [
   RECEIVING_COLUMNS.TITLE,
+  RECEIVING_COLUMNS.VENDOR,
   RECEIVING_COLUMNS.EXPECTED_RECEIPT_DATE,
   RECEIVING_COLUMNS.TITLE_OR_PACKAGE,
   RECEIVING_COLUMNS.PO_LINE_NUMBER,
@@ -28,6 +30,7 @@ export const RECEIVING_MANDATORY_COLUMNS = [RECEIVING_COLUMNS.TITLE];
 
 export const RECEIVING_COLUMN_MAPPING = {
   [RECEIVING_COLUMNS.TITLE]: <FormattedMessage id="ui-receiving.titles.title" />,
+  [RECEIVING_COLUMNS.VENDOR]: <FormattedMessage id="ui-receiving.title.vendor" />,
   [RECEIVING_COLUMNS.EXPECTED_RECEIPT_DATE]: <FormattedMessage id="ui-receiving.title.expectedReceiptDate" />,
   [RECEIVING_COLUMNS.TITLE_OR_PACKAGE]: <FormattedMessage id="ui-receiving.title.package" />,
   [RECEIVING_COLUMNS.PO_LINE_NUMBER]: <FormattedMessage id="ui-receiving.title.polNumber" />,

--- a/src/ReceivingList/utils.js
+++ b/src/ReceivingList/utils.js
@@ -205,7 +205,7 @@ export const fetchLinesOrders = (ky, lines, fetchedOrdersMap) => {
 };
 
 export const fetchOrdersVendors = (ky, orders) => {
-  const vendorIds = uniq(orders.map(({ vendor }) => vendor).filter(Boolean));
+  const vendorIds = [...new Set(orders.map(({ vendor }) => vendor).filter(Boolean))];
 
   return batchRequest(
     ({ params: searchParams }) => (

--- a/src/ReceivingList/utils.js
+++ b/src/ReceivingList/utils.js
@@ -18,6 +18,7 @@ import {
   LINES_API,
   LOCATIONS_API,
   ORDERS_API,
+  VENDORS_API,
 } from '@folio/stripes-acq-components';
 
 import { BATCH_IDENTIFIER_TYPE } from '../common/constants';
@@ -201,4 +202,17 @@ export const fetchLinesOrders = (ky, lines, fetchedOrdersMap) => {
       uniq(unfetched),
     )
     : Promise.resolve([]);
+};
+
+export const fetchOrdersVendors = (ky, orders) => {
+  const vendorIds = uniq(orders.map(({ vendor }) => vendor).filter(Boolean));
+
+  return batchRequest(
+    ({ params: searchParams }) => (
+      ky.get(VENDORS_API, { searchParams })
+        .json()
+        .then(({ organizations }) => organizations)
+    ),
+    vendorIds,
+  );
 };

--- a/src/ReceivingList/utils.test.js
+++ b/src/ReceivingList/utils.test.js
@@ -6,6 +6,7 @@ import {
   LINES_API,
   LOCATIONS_API,
   ORDER_FORMATS,
+  VENDORS_API,
 } from '@folio/stripes-acq-components';
 
 import {
@@ -19,6 +20,7 @@ import {
   fetchTitleOrderLines,
   fetchOrderLineHoldings,
   fetchOrderLineLocations,
+  fetchOrdersVendors,
   buildTitlesQuery,
 } from './utils';
 
@@ -196,6 +198,35 @@ describe('ReceivingList utils', () => {
           expect(ky.get).not.toHaveBeenCalled();
           expect(response).toEqual([]);
         });
+    });
+  });
+
+  describe('fetchOrdersVendors', () => {
+    it('should make a request with unique vendor ids', async () => {
+      const ky = {
+        get: jest.fn(() => ({
+          json: () => Promise.resolve({ organizations: [] }),
+        })),
+      };
+      const orders = [{ vendor: 1 }, { vendor: 2 }, { vendor: 2 }];
+
+      await fetchOrdersVendors(ky, orders);
+
+      expect(ky.get).toHaveBeenCalledWith(VENDORS_API, expect.objectContaining({
+        searchParams: {
+          limit: LIMIT_MAX,
+          query: 'id==1 or id==2',
+        },
+      }));
+    });
+
+    it('should not make a request when orders have no vendor', async () => {
+      const ky = { get: jest.fn() };
+
+      const response = await fetchOrdersVendors(ky, [{}]);
+
+      expect(ky.get).not.toHaveBeenCalled();
+      expect(response).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Purpose

Staff handling high-volume serial check-in regularly see identical journal titles in the Receiving results list, because the same title is supplied by different vendors (print vs. electronic subscription) or ordered separately for different branches. Today the only way to tell those rows apart is to open each record. This adds a "Vendor" column to the results list so the distinction is visible at a glance.

Reference: https://folio-org.atlassian.net/browse/UIREC-499

## Approach

1. `fetchOrdersVendors` (`utils.js`) resolves the vendor UUIDs of the already fetched purchase orders through `batchRequest`.
2. `ReceivingListContainer` maps the names onto the order lines, `ReceivingList` renders the name or `<NoValue />` when it cannot be resolved (deleted organization, or no permission to read organizations).
3. The column is second, visible by default and can be hidden through the column manager. Like the other reference fields resolved in `fetchReferences` (`locations`, `orderWorkflow`) it is not sortable, since `orders/titles` only knows the vendor as a UUID. The ticket covers this under "Out of scope".

## Performance

Addressing the concern raised in the ticket: no extra order fetch is needed. `fetchLinesOrders` already loads the purchase orders for the existing "Order workflow" column, and each order carries its `vendor` UUID. Resolving those to names is one batched request against `organizations`, in practice a single one per page.

What it would have cost is latency, appended to the end of the `await` chain in `fetchReferences`. The second commit removes that: holdings/locations and orders/vendors are two independent chains starting from the order lines, so they now run side by side via `Promise.all`. Requests inside `fetchReferences`:

| | requests | sequential rounds |
|---|---|---|
| before | 4 | 4 |
| with vendor, appended sequentially | 5 | 5 |
| this PR | 5 | **3** |

Three rounds is the floor, since each second call needs ids from the first. The refactor is a separate commit so it can be reviewed on its own.

## Cross-tenant

The `crossTenant` branches from UIREC-509 are carried over unchanged into the new `fetchHoldingsAndLocations` helper: same calls, same arguments, only the indentation differs. We have no ECS setup available locally to exercise that path, so a look at it during review would be appreciated.

## Screenshot

<img width="3456" height="2160" alt="image-20260805-065748" src="https://github.com/user-attachments/assets/7e1c5783-dadd-407a-95a2-2b4a963b5643" />
<img width="3456" height="2160" alt="image-20260805-065629" src="https://github.com/user-attachments/assets/3dd35e8b-72d0-4831-b157-4c95a39df824" />


Refs [UIREC-499](https://folio-org.atlassian.net/browse/UIREC-499)
